### PR TITLE
issue #1 - do not allow a pod to define what tenant it writes to

### DIFF
--- a/src/github.com/hawkular/hawkular-openshift-agent/k8s/configmap_entry.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/k8s/configmap_entry.go
@@ -23,15 +23,12 @@ const (
 // Type indicates the kind of metric endpoint (e.g. Prometheus or Jolokia).
 // Protocol defines the communications protocol (e.g. http or https).
 // Notice that Host is not defined - it will be determined at runtime via the pod configuration.
-// If tenant is not supplied, the global tenant ID defined
-// in the global agent configuration file should be used.
 // USED FOR YAML
 type K8SEndpoint struct {
 	Type                     collector.EndpointType
 	Protocol                 K8SEndpointProtocol
 	Port                     int
 	Path                     string
-	Tenant                   string
 	Collection_Interval_Secs int
 	Metrics                  []K8SMetric
 }

--- a/src/github.com/hawkular/hawkular-openshift-agent/k8s/node_event_consumer.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/k8s/node_event_consumer.go
@@ -143,11 +143,13 @@ func (nec *NodeEventConsumer) startCollecting(ne *NodeEvent) {
 			continue
 		}
 
-		// we need to convert the k8s endpoint to the generic endpoint struct
+		// We need to convert the k8s endpoint to the generic endpoint struct.
+		// Note that the tenant for all metrics collected from this endpoint
+		// must be the same as the namespace of the pod where the endpoint is located
 		newEndpoint := &collector.Endpoint{
 			Url:    url.String(),
 			Type:   cmeEndpoint.Type,
-			Tenant: cmeEndpoint.Tenant,
+			Tenant: ne.Namespace,
 			Collection_Interval_Secs: cmeEndpoint.Collection_Interval_Secs,
 			Metrics:                  make([]collector.MonitoredMetric, len(cmeEndpoint.Metrics)),
 		}


### PR DESCRIPTION
Tenant must always be the same name as the pod's namespace