### PR TITLE
issue #4 tag metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,17 @@ notifications:
     channels:
     - chat.freenode.net#hawkular
 
+# Workaround issue https://github.com/Masterminds/glide/issues/639
+# Run this before_install and do not run "make install_glide" during the install.
+before_install:
+  - GLIDE_OS_ARCH=`go env GOHOSTOS`-`go env GOHOSTARCH`
+  - GLIDE_TAG=$(curl -s https://glide.sh/version)
+  - GLIDE_LATEST_RELEASE_URL="https://github.com/Masterminds/glide/releases/download/${GLIDE_TAG}/glide-${GLIDE_TAG}-${GLIDE_OS_ARCH}.tar.gz"
+  - wget ${GLIDE_LATEST_RELEASE_URL} -O /tmp/glide.tar.gz
+  - mkdir /tmp/glide
+  - tar --directory=/tmp/glide -xvf /tmp/glide.tar.gz
+  - export PATH=$PATH:/tmp/glide/${GLIDE_OS_ARCH}
+
 # Our source code layout is the full GOPATH location.
 # This is different than how Travis expects so let's tell Travis
 # to change its environment to point to the proper GOPATH.
@@ -17,7 +28,7 @@ install:
   - export GOPATH=${TRAVIS_BUILD_DIR}
   - export PATH=${GOPATH}/bin:${PATH}
   - go env
-  - make install_glide
+#  - make install_glide
   - make install_deps
 
 script: make test

--- a/README.adoc
+++ b/README.adoc
@@ -111,7 +111,7 @@ Hawkular OpenShift Agent examines each pod on the node and by cross-referencing 
 
 Suppose you have a node running a project called "my-project" that consists of 3 pods (named "web-pod", "app-pod", and "db-pod"). Suppose you do not want Hawkular OpenShift Agent to monitor the "db-pod" but you do want it to monitor the other two pods in your project.
 
-First create two config maps on your "my-project" that each contain a config map entry that indicate what you want to monitor on your two pods. One way you can do this is create a YAML file that represents your config maps and via the "oc" Open Shift command line tool create the config maps. A sample YAML configuration for the web-pod config map could look like this (the schema of this YAML will change in the future, this is just an example).
+First create two config maps on your "my-project" that each contain a config map entry that indicate what you want to monitor on your two pods. One way you can do this is create a YAML file that represents your config maps and via the "oc" OpenShift command line tool create the config maps. A sample YAML configuration for the web-pod config map could look like this (the schema of this YAML will change in the future, this is just an example).
 
 [source,yaml]
 ----
@@ -197,7 +197,9 @@ A full Prometheus endpoint configuration can look like this:
   metrics:
   - name: go_memstats_last_gc_time_seconds
     id: gc_time_secs
+    type: gauge
   - name: go_memstats_frees_total
+    type: counter
 ----
 
 Some things to note about configuring your Prometheus endpoints:
@@ -214,7 +216,6 @@ identity:
 ----
 * The credentials are optional. If the Prometheus endpoint does require authorization, you can specify the credentials as either a bearer token or a basic username/password.
 * A metric "id" is used when storing the metric to Hawkular Metrics. If you do not specify an "id" for a metric, its "name" will be used as the default.
-* You do not specify a metric's "type" since it will be determined directly from the Prometheus data itself.
 
 == Jolokia Endpoints
 
@@ -367,3 +368,79 @@ kubernetes:
   ca_cert_file: VALUE
 ----
 |===
+
+== Metric Tags
+
+Metric data can be tagged with additional metadata called _tags_. A metric tag is a simple name/value pair. Tagging metrics allows you to further describe the metric and allows you to query for metric data based on tag queries. For more information on tags and querying tagged metric data, see the Hawkular-Metrics documentation.
+
+Hawkular OpenShift Agent can be configured to attach custom tags to the metrics it collects. There are three places where you can define custom tags in Hawkular OpenShift Agent:
+
+* In the global configuration of the agent (all tags defined here will be attached to all metrics stored by the agent)
+* In an endpoint configuration (all tags defined here will be attached to all metrics collected from that endpoint)
+* In a metric configuration (all tags defined here will only be attached to the metric)
+
+To define global tags, you would add a top-level `tags` section in the global agent configuration file. The following configuration snippet will tell the agent to attach the tags "my-tag" (with value "my-tag-value") and "another-tag" (with value "another-tag-value") to each and every metric the agent collects.
+
+[source,yaml]
+----
+tags:
+- my-tag: my-tag-value
+- another-tag: another-tag-value
+----
+
+To define endpoint tags (that is, tags that will be attached to every metric collected from the endpoint), you would add a `tags` section within the endpoint configuration. The following configuration snippet will tell the agent to attach the tags "my-endpoint-tag" and "my-other-endpoint-tag" to every metric that is collected from this specific Jolokia endpoint:
+
+[source,yaml]
+----
+endpoints:
+- type: jolokia
+  tags:
+    my-endpoint-tag: the-endpoint-tag-value
+    my-other-endpoint-tag: the-endpoint-tag-value
+----
+
+To define tags on individual metrics, you would add a `tags` section within a metric configuration. The following configuration snippet will tell the agent to attach the tags "my-metric-tag" and "my-other-metric-tag" to the metric named "java.lang.type=Threading#ThreadCount" that is collected from this specific Jolokia endpoint:
+
+[source,yaml]
+----
+endpoints:
+- type: jolokia
+  metrics:
+  - name: java.lang.type=Threading#ThreadCount
+    type: gauge
+    tags:
+      my-metric-tag: the-metric-tag-value
+      my-other-metric-tag: the-metric-tag-value
+----
+
+Tag values can be defined with token expressions in the form of `${var}` or `$var` where _var_ is either an agent environment variable name or (if the tag definition is found in an OpenShift configmap entry) one of the following:
+
+[cols="1,1a"]
+|===
+|Token Name|Description
+
+|POD:nodename
+|The name of the node where the metric was collected from.
+
+|POD:namespace
+|The namespace of the pod where the metric was collected from.
+
+|POD:name
+|The name of the pod where the metric was collected from.
+
+|POD:ipaddress
+|The IP address of the pod where the metric was collected from.
+
+|POD:uid
+|The UID of the pod where the metric was collected from.
+|===
+
+For example:
+
+[source,yaml]
+----
+tags:
+  my-user-tag: my-agent-user=$USER
+  my-pod-name: ${POD:name}
+  some-env-tag: ${SOME_ENV_VAR}
+----

--- a/src/github.com/hawkular/hawkular-openshift-agent/collector/impl/jolokia_metrics_collector.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/collector/impl/jolokia_metrics_collector.go
@@ -91,14 +91,9 @@ func (jc *JolokiaMetricsCollector) CollectMetrics() (metrics []hmetrics.MetricHe
 				Value:     resp.GetValueAsFloat(),
 			}
 
-			id := jc.Endpoint.Metrics[i].Id
-			if id == "" {
-				id = jc.Endpoint.Metrics[i].Name
-			}
-
 			metric := hmetrics.MetricHeader{
 				Type:   jc.Endpoint.Metrics[i].Type,
-				ID:     id,
+				ID:     jc.Endpoint.Metrics[i].Id,
 				Tenant: jc.Endpoint.Tenant,
 				Data:   data,
 			}

--- a/src/github.com/hawkular/hawkular-openshift-agent/config/config.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hawkular/hawkular-openshift-agent/collector"
 	"github.com/hawkular/hawkular-openshift-agent/config/security"
+	"github.com/hawkular/hawkular-openshift-agent/config/tags"
 	"github.com/hawkular/hawkular-openshift-agent/log"
 )
 
@@ -63,12 +64,14 @@ type Kubernetes struct {
 }
 
 // Config defines the agent's full YAML configuration.
+// Tags specified here will be attached to all metrics this agent collects and stores.
 // USED FOR YAML
 type Config struct {
 	Identity        security.Identity ",omitempty"
 	Hawkular_Server Hawkular_Server
 	Collector       Collector            ",omitempty"
 	Kubernetes      Kubernetes           ",omitempty"
+	Tags            tags.Tags            ",omitempty"
 	Endpoints       []collector.Endpoint ",omitempty"
 }
 

--- a/src/github.com/hawkular/hawkular-openshift-agent/config/config_test.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/hawkular/hawkular-openshift-agent/collector"
+	"github.com/hawkular/hawkular-openshift-agent/config/security"
+	"github.com/hawkular/hawkular-openshift-agent/config/tags"
 )
 
 func TestEnvVar(t *testing.T) {
@@ -126,6 +128,10 @@ func TestMarshalUnmarshal(t *testing.T) {
 
 func TestLoadSave(t *testing.T) {
 	testConf := Config{
+		Identity: security.Identity{
+			Cert_File:        "/my/cert",
+			Private_Key_File: "/my/key",
+		},
 		Collector: Collector{
 			Minimum_Collection_Interval_Secs: 12345,
 		},
@@ -135,6 +141,10 @@ func TestLoadSave(t *testing.T) {
 		Kubernetes: Kubernetes{
 			Pod_Namespace: "TestLoadSave namespace",
 			Pod_Name:      "TestLoadSave name",
+		},
+		Tags: tags.Tags{
+			"tag1": "tagvalue1",
+			"tag2": "tagvalue2",
 		},
 		Endpoints: []collector.Endpoint{
 			{
@@ -163,6 +173,14 @@ func TestLoadSave(t *testing.T) {
 		t.Errorf("Failed to load from file: %v", err)
 	}
 
+	t.Logf("Config from file\n%v", conf)
+
+	if conf.Identity.Cert_File != "/my/cert" {
+		t.Errorf("Failed to unmarshal identity:\n%v", conf)
+	}
+	if conf.Identity.Private_Key_File != "/my/key" {
+		t.Errorf("Failed to unmarshal identity:\n%v", conf)
+	}
 	if conf.Collector.Minimum_Collection_Interval_Secs != 12345 {
 		t.Errorf("Failed to unmarshal collection interval:\n%v", conf)
 	}
@@ -180,6 +198,12 @@ func TestLoadSave(t *testing.T) {
 	}
 	if conf.Endpoints[1].Collection_Interval_Secs != 234 {
 		t.Error("Second endpoint is not correct")
+	}
+	if conf.Tags["tag1"] != "tagvalue1" {
+		t.Error("Tag1 is not correct")
+	}
+	if conf.Tags["tag2"] != "tagvalue2" {
+		t.Error("Tag2 is not correct")
 	}
 
 }

--- a/src/github.com/hawkular/hawkular-openshift-agent/config/tags/config_tags.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/config/tags/config_tags.go
@@ -1,0 +1,57 @@
+package tags
+
+import (
+	"os"
+)
+
+// Identifies a list of name=value tags
+// USED FOR YAML
+type Tags map[string]string
+
+func (t *Tags) AppendTags(moreTags map[string]string) {
+	if moreTags != nil && len(moreTags) > 0 {
+		for k, v := range moreTags {
+			(*t)[k] = v
+		}
+	}
+}
+
+// ExpandTokens will replace all tag values such that $name or ${name}
+// expressions are replaced with their corresponding values found in either
+// the operating system environment variable table and/or the given
+// additional environment map.
+// If useOsEnv is false, the OS environment variables are not used.
+// If additionalEnv is nil, it is ignored.
+// If a name is found in both the OS environment and additionalEnv, the
+// additionalEnv value will be used to replace the $name token.
+// If a name is not found, an empty string is used to replace the $name token.
+// If you want a literal $ in the string, use $$.
+func (t *Tags) ExpandTokens(useOsEnv bool, additionalEnv *map[string]string) {
+	if t == nil {
+		return
+	}
+
+	mappingFunc := func(s string) string {
+		if s == "$" {
+			return "$" // a $$ means the user wants a literal "$" character
+		}
+
+		if additionalEnv != nil {
+			if val, ok := (*additionalEnv)[s]; ok {
+				return val
+			}
+		}
+
+		if useOsEnv {
+			if val, ok := os.LookupEnv(s); ok {
+				return val
+			}
+		}
+
+		return ""
+	}
+
+	for k, v := range *t {
+		(*t)[k] = os.Expand(v, mappingFunc)
+	}
+}

--- a/src/github.com/hawkular/hawkular-openshift-agent/config/tags/config_tags_test.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/config/tags/config_tags_test.go
@@ -1,0 +1,116 @@
+package tags
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestAppend(t *testing.T) {
+	tags := Tags{
+		"tag0": "tagvalue0",
+	}
+
+	more := map[string]string{
+		"another": "anothervalue",
+		"lastone": "lastvalue",
+	}
+
+	tags.AppendTags(more)
+
+	if len(tags) != 3 {
+		t.Fatalf("Failed to append tags: %v", tags)
+	}
+
+	assertTagValue(t, tags, "tag0", "tagvalue0")
+	assertTagValue(t, tags, "another", "anothervalue")
+	assertTagValue(t, tags, "lastone", "lastvalue")
+}
+
+func TestReplaceEnvVars(t *testing.T) {
+	envvar1 := "first envvar"
+	defer os.Unsetenv("TEST_FIRST_ENVVAR")
+	os.Setenv("TEST_FIRST_ENVVAR", envvar1)
+
+	envvar2 := "second envvar"
+	defer os.Unsetenv("TEST_SECOND_ENVVAR")
+	os.Setenv("TEST_SECOND_ENVVAR", envvar2)
+
+	tags := Tags{
+		"tag0": "tagvalue 0 with no tokens!",
+		"tag1": "$TEST_FIRST_ENVVAR",
+		"tag2": "prefix$TEST_FIRST_ENVVAR",
+		"tag3": "${TEST_FIRST_ENVVAR}postfix",
+		"tag4": "prefix${TEST_FIRST_ENVVAR}postfix",
+		"tag5": "${TEST_FIRST_ENVVAR}${TEST_SECOND_ENVVAR}",
+		"tag6": "A${TEST_FIRST_ENVVAR}B${TEST_SECOND_ENVVAR}C",
+		"tag7": "$THIS_DOES_NOT_EXIST",
+		"tag8": "$$literal",
+	}
+
+	tags.ExpandTokens(true, nil)
+
+	assertTagValue(t, tags, "tag0", "tagvalue 0 with no tokens!")
+	assertTagValue(t, tags, "tag1", envvar1)
+	assertTagValue(t, tags, "tag2", "prefix"+envvar1)
+	assertTagValue(t, tags, "tag3", envvar1+"postfix")
+	assertTagValue(t, tags, "tag4", "prefix"+envvar1+"postfix")
+	assertTagValue(t, tags, "tag5", envvar1+envvar2)
+	assertTagValue(t, tags, "tag6", fmt.Sprintf("A%vB%vC", envvar1, envvar2))
+	assertTagValue(t, tags, "tag7", "")
+	assertTagValue(t, tags, "tag8", "$literal")
+}
+
+func TestAdditionalValues(t *testing.T) {
+
+	tags := Tags{"tag1": "$not_a_env_var"}
+	tags.ExpandTokens(false, &map[string]string{"not_a_env_var": "some value"})
+	assertTagValue(t, tags, "tag1", "some value")
+
+	tags = Tags{"tag1": "the sum of $one plus $two is ${three}"}
+	tags.ExpandTokens(false, &map[string]string{
+		"one":    "1",
+		"two":    "2",
+		"three":  "3",
+		"unused": "?",
+	})
+	assertTagValue(t, tags, "tag1", "the sum of 1 plus 2 is 3")
+}
+
+func TestSpecialCharsInNames(t *testing.T) {
+
+	tags := Tags{"tag1": "pod name is ${POD:Name} p|a = ${p|a}"}
+	tags.ExpandTokens(false, &map[string]string{
+		"POD:Name": "foo",
+		"p|a":      "bar",
+	})
+	assertTagValue(t, tags, "tag1", "pod name is foo p|a = bar")
+}
+
+func TestOverrideEnvVar(t *testing.T) {
+	envvar1 := "first envvar"
+	defer os.Unsetenv("TEST_FIRST_ENVVAR")
+	os.Setenv("TEST_FIRST_ENVVAR", envvar1)
+
+	tags := Tags{"tag1": "$TEST_FIRST_ENVVAR"}
+	tags.ExpandTokens(true, nil)
+	assertTagValue(t, tags, "tag1", envvar1)
+
+	tags = Tags{"tag1": "$TEST_FIRST_ENVVAR"}
+	tags.ExpandTokens(false, nil)
+	assertTagValue(t, tags, "tag1", "")
+
+	tags = Tags{"tag1": "$TEST_FIRST_ENVVAR"}
+	tags.ExpandTokens(true, &map[string]string{"TEST_FIRST_ENVVAR": "override value"})
+	assertTagValue(t, tags, "tag1", "override value")
+
+	tags = Tags{"tag1": "$TEST_FIRST_ENVVAR"}
+	tags.ExpandTokens(false, &map[string]string{"TEST_FIRST_ENVVAR": "override value"})
+	assertTagValue(t, tags, "tag1", "override value")
+}
+
+func assertTagValue(t *testing.T, tags Tags, key string, expected string) {
+	if tags[key] != expected {
+		t.Fatalf("Tag [%v] should have been [%v] but was [%v]", key, expected, tags[key])
+	}
+}

--- a/src/github.com/hawkular/hawkular-openshift-agent/glide.lock
+++ b/src/github.com/hawkular/hawkular-openshift-agent/glide.lock
@@ -1,5 +1,5 @@
 hash: 9cf7d7776c91815b858479ffe9402b7fe31ed08866ca61f7eb5c1f45225c5d08
-updated: 2016-10-19T16:37:53.998409112-04:00
+updated: 2016-10-31T09:47:17.806678452-04:00
 imports:
 - name: github.com/blang/semver
   version: 60ec3488bfea7cca02b021d106d9911120d25fe9
@@ -35,7 +35,7 @@ imports:
 - name: github.com/google/gofuzz
   version: fd52762d25a41827db7ef64c43756fd4b9f7e382
 - name: github.com/hawkular/hawkular-client-go
-  version: 4f5da7e951592445b686f95a0acdb0f860095d70
+  version: 72ea12c211dba93fb6cda6341a0fe3dd89db8a2b
   subpackages:
   - metrics
 - name: github.com/juju/ratelimit

--- a/src/github.com/hawkular/hawkular-openshift-agent/k8s/configmap_entry.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/k8s/configmap_entry.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hawkular/hawkular-openshift-agent/collector"
 	"github.com/hawkular/hawkular-openshift-agent/config/security"
+	"github.com/hawkular/hawkular-openshift-agent/config/tags"
 	"github.com/hawkular/hawkular-openshift-agent/log"
 )
 
@@ -31,6 +32,7 @@ type K8SEndpoint struct {
 	Path                     string
 	Credentials              security.Credentials
 	Collection_Interval_Secs int
+	Tags                     tags.Tags
 	Metrics                  []collector.MonitoredMetric
 }
 
@@ -46,7 +48,7 @@ func (e K8SEndpoint) GetUrl(host string) (u *url.URL, err error) {
 	if e.Path[0] == '/' {
 		leadingSlash = ""
 	}
-	u, err = url.Parse(fmt.Sprintf("%v://%v:%v%v%v)", e.Protocol, host, e.Port, leadingSlash, e.Path))
+	u, err = url.Parse(fmt.Sprintf("%v://%v:%v%v%v", e.Protocol, host, e.Port, leadingSlash, e.Path))
 	return
 }
 

--- a/src/github.com/hawkular/hawkular-openshift-agent/k8s/configmap_test.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/k8s/configmap_test.go
@@ -6,6 +6,7 @@ import (
 	hmetrics "github.com/hawkular/hawkular-client-go/metrics"
 
 	"github.com/hawkular/hawkular-openshift-agent/collector"
+	"github.com/hawkular/hawkular-openshift-agent/config/tags"
 )
 
 func TestYamlText(t *testing.T) {
@@ -21,6 +22,9 @@ func TestYamlText(t *testing.T) {
 				Id:   "metric1id",
 				Type: hmetrics.Gauge,
 				Name: "metric1",
+				Tags: tags.Tags{
+					"tag1": "tag1value",
+				},
 			},
 			collector.MonitoredMetric{
 				Id:   "metric2id",
@@ -62,10 +66,18 @@ endpoints:
   port: 8888
   path: /the/path
   collection_interval_secs: 12345
+  tags:
+    endpointtagname1: endpointtag1
+    endpointtagname2: endpointtag2
+    endpointtagname3: endpointtag3
   metrics:
   - id: metric1id
     name: metric1
     type: gauge
+    tags:
+      tagname1: tagvalue1
+      tagname2: ${POD:name}
+      tagname3: $HOSTNAME
   - id: metric2id
     name: metric2
     type: counter
@@ -101,6 +113,24 @@ endpoints:
 	}
 	if cme.Endpoints[0].Metrics[0].Type != hmetrics.Gauge {
 		t.Fatalf("Endpoint.Metrics[0] type is wrong")
+	}
+	if cme.Endpoints[0].Tags["endpointtagname1"] != "endpointtag1" {
+		t.Fatalf("Endpoint tag 1 is wrong")
+	}
+	if cme.Endpoints[0].Tags["endpointtagname2"] != "endpointtag2" {
+		t.Fatalf("Endpoint tag 2 is wrong")
+	}
+	if cme.Endpoints[0].Tags["endpointtagname3"] != "endpointtag3" {
+		t.Fatalf("Endpoint tag 3 is wrong")
+	}
+	if cme.Endpoints[0].Metrics[0].Tags["tagname1"] != "tagvalue1" {
+		t.Fatalf("Endpoint.Metrics[0] tag 1 is wrong")
+	}
+	if cme.Endpoints[0].Metrics[0].Tags["tagname2"] != "${POD:name}" {
+		t.Fatalf("Endpoint.Metrics[0] tag 2 is wrong")
+	}
+	if cme.Endpoints[0].Metrics[0].Tags["tagname3"] != "$HOSTNAME" {
+		t.Fatalf("Endpoint.Metrics[0] tag 3 is wrong")
 	}
 
 	yaml2, err := MarshalConfigMapEntry(cme)

--- a/src/github.com/hawkular/hawkular-openshift-agent/k8s/node_event.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/k8s/node_event.go
@@ -16,7 +16,7 @@ const (
 
 // NodeEvent indicates when something changed with the node (either a pod or config map changed)
 type NodeEvent struct {
-	Trigger
-	*Pod
-	*ConfigMapEntry
+	Trigger        Trigger
+	Pod            *Pod
+	ConfigMapEntry *ConfigMapEntry
 }

--- a/src/github.com/hawkular/hawkular-openshift-agent/storage/metrics_storage.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/storage/metrics_storage.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"reflect"
+
 	"github.com/golang/glog"
 	hmetrics "github.com/hawkular/hawkular-client-go/metrics"
 
@@ -9,33 +11,101 @@ import (
 )
 
 type MetricsStorageManager struct {
-	MetricsChannel chan []hmetrics.MetricHeader
-	hawkularClient *hmetrics.Client
-	globalConfig   *config.Config
+	MetricsChannel              chan []hmetrics.MetricHeader
+	MetricDefinitionsChannel    chan []hmetrics.MetricDefinition
+	hawkClientMetrics           *hmetrics.Client
+	hawkClientMetricDefinitions *hmetrics.Client
+	globalConfig                *config.Config
 }
 
 func NewMetricsStorageManager(conf *config.Config) (ms *MetricsStorageManager, err error) {
-	client, err := getHawkularMetricsClient(conf)
+	// create one client for metrics and another for definitions - this way no concurrency issues to worry about
+	clientMetrics, err := getHawkularMetricsClient(conf)
+	if err != nil {
+		return nil, err
+	}
+	clientMetricDefs, err := getHawkularMetricsClient(conf)
 	if err != nil {
 		return nil, err
 	}
 
 	ms = &MetricsStorageManager{
-		MetricsChannel: make(chan []hmetrics.MetricHeader, 100),
-		hawkularClient: client,
-		globalConfig:   conf,
+		MetricsChannel:              make(chan []hmetrics.MetricHeader, 100),
+		MetricDefinitionsChannel:    make(chan []hmetrics.MetricDefinition, 100),
+		hawkClientMetrics:           clientMetrics,
+		hawkClientMetricDefinitions: clientMetricDefs,
+		globalConfig:                conf,
 	}
 	return
 }
 
 func (ms *MetricsStorageManager) StartStoringMetrics() {
-	glog.Info("START storing metrics")
+	glog.Info("START storing metrics definitions and data")
+	go ms.consumeMetricDefinitions()
 	go ms.consumeMetrics()
 }
 
 func (ms *MetricsStorageManager) StopStoringMetrics() {
-	glog.Info("STOP storing metrics")
+	glog.Info("STOP storing metrics definitions and data")
 	close(ms.MetricsChannel)
+	close(ms.MetricDefinitionsChannel)
+}
+
+func (ms *MetricsStorageManager) consumeMetricDefinitions() {
+	for metricDefs := range ms.MetricDefinitionsChannel {
+		if len(metricDefs) == 0 {
+			continue
+		}
+
+		// If a tenant is provided, use it. Otherwise, use the global tenant.
+		// This assumes all metric defs in the given array are associated with the same tenant.
+		var tenant string
+		if metricDefs[0].Tenant != "" {
+			tenant = metricDefs[0].Tenant
+		} else {
+			tenant = ms.globalConfig.Hawkular_Server.Tenant
+		}
+
+		modifier := hmetrics.Tenant(tenant)
+
+		// Store the metric definitions to H-Metrics.
+		for _, md := range metricDefs {
+			existing, err := ms.hawkClientMetricDefinitions.Definition(md.Type, md.ID, modifier)
+			if existing == nil {
+				if err == nil {
+					// doesn't exist - create it
+					ok, createErr := ms.hawkClientMetricDefinitions.Create(md, modifier)
+					if !ok {
+						glog.Warningf("Failed to create new metric definition [%v] of type [%v] in tenant [%v]. err=%v", md.ID, md.Type, tenant, createErr)
+					}
+				} else {
+					glog.Warningf("Failed to determine if metric definition [%v] of type [%v] in tenant [%v] exists. err=%v", md.ID, md.Type, tenant, err)
+				}
+			} else {
+				// metric def exists, we just need to update it if it needs to be
+				if !reflect.DeepEqual(md.Tags, existing.Tags) {
+					log.Debugf("Deleting obsolete tags from metric definition [%v] of type [%v] in tenant [%v]", md.ID, md.Type, tenant)
+					// if there are tags that currently exist but no longer should, delete them
+					for existingTagName, existingTagValue := range existing.Tags {
+						if _, ok := md.Tags[existingTagName]; !ok {
+							log.Tracef("Deleting obsolete tag [%v] from metric definition [%v] of type [%v] in tenant [%v].", existingTagName, md.ID, md.Type, tenant)
+							err := ms.hawkClientMetricDefinitions.DeleteTags(md.Type, md.ID, map[string]string{existingTagName: existingTagValue}, modifier)
+							if err != nil {
+								glog.Warningf("Failed to delete obsolete tag [%v=%v] from metric definition [%v] of type [%v] in tenant [%v]. err=%v", existingTagName, existingTagValue, md.ID, md.Type, tenant, err)
+							}
+						}
+					}
+
+					// now update any existing/new ones
+					log.Debugf("Updating tags for metric definition [%v] of type [%v] in tenant [%v]", md.ID, md.Type, tenant)
+					err := ms.hawkClientMetricDefinitions.UpdateTags(md.Type, md.ID, md.Tags, modifier)
+					if err != nil {
+						glog.Warningf("Failed to update tags for metric definition [%v] of type [%v] in tenant [%v]. err=%v", md.ID, md.Type, tenant, err)
+					}
+				}
+			}
+		}
+	}
 }
 
 func (ms *MetricsStorageManager) consumeMetrics() {
@@ -54,7 +124,7 @@ func (ms *MetricsStorageManager) consumeMetrics() {
 		}
 
 		// Store the metrics to H-Metrics.
-		err := ms.hawkularClient.Write(metrics, hmetrics.Tenant(tenant))
+		err := ms.hawkClientMetrics.Write(metrics, hmetrics.Tenant(tenant))
 
 		if err != nil {
 			glog.Warningf("Failed to store metrics. err=%v", err)


### PR DESCRIPTION
Creates metric definitions and add tags to them. You can define tags globally (across all endpoints and all tags), per endpoint (all metrics from the same endpoint can be tagged), and per metric (that particular metric can have its own tags).

You can define tag values with $[x} expressions where x can be an environment variable or (if it is a tag on an OpenShift endpoint) ${POD:y} where y is one of "nodename", "namespace", "name", "uid", "ipaddress"

Due to bug in h-metrics, avoid spaces in tag values - see https://issues.jboss.org/browse/HWKMETRICS-530