### PR TITLE
provide global tags with pod-specific environment tokens

### DIFF
--- a/src/github.com/hawkular/hawkular-openshift-agent/collector/impl/jolokia_metrics_collector.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/collector/impl/jolokia_metrics_collector.go
@@ -16,17 +16,20 @@ import (
 )
 
 type JolokiaMetricsCollector struct {
-	Id       string
-	Identity *security.Identity
-	Endpoint *collector.Endpoint
+	Id          string
+	Identity    *security.Identity
+	Endpoint    *collector.Endpoint
+	Environment map[string]string
 }
 
-func NewJolokiaMetricsCollector(id string, identity security.Identity, endpoint collector.Endpoint) (mc *JolokiaMetricsCollector) {
+func NewJolokiaMetricsCollector(id string, identity security.Identity, endpoint collector.Endpoint, env map[string]string) (mc *JolokiaMetricsCollector) {
 	mc = &JolokiaMetricsCollector{
-		Id:       id,
-		Identity: &identity,
-		Endpoint: &endpoint,
+		Id:          id,
+		Identity:    &identity,
+		Endpoint:    &endpoint,
+		Environment: env,
 	}
+
 	return
 }
 
@@ -38,6 +41,11 @@ func (jc *JolokiaMetricsCollector) GetId() string {
 // GetEndpoint implements a method from MetricsCollector interface
 func (jc *JolokiaMetricsCollector) GetEndpoint() *collector.Endpoint {
 	return jc.Endpoint
+}
+
+// GetAdditionalEnvironment implements a method from MetricsCollector interface
+func (jc *JolokiaMetricsCollector) GetAdditionalEnvironment() map[string]string {
+	return jc.Environment
 }
 
 // CollectMetrics does the real work of actually connecting to a remote Jolokia endpoint,

--- a/src/github.com/hawkular/hawkular-openshift-agent/collector/impl/prometheus_metrics_collector.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/collector/impl/prometheus_metrics_collector.go
@@ -20,14 +20,16 @@ type PrometheusMetricsCollector struct {
 	Id              string
 	Identity        *security.Identity
 	Endpoint        *collector.Endpoint
+	Environment     map[string]string
 	metricNameIdMap map[string]string
 }
 
-func NewPrometheusMetricsCollector(id string, identity security.Identity, endpoint collector.Endpoint) (mc *PrometheusMetricsCollector) {
+func NewPrometheusMetricsCollector(id string, identity security.Identity, endpoint collector.Endpoint, env map[string]string) (mc *PrometheusMetricsCollector) {
 	mc = &PrometheusMetricsCollector{
-		Id:       id,
-		Identity: &identity,
-		Endpoint: &endpoint,
+		Id:          id,
+		Identity:    &identity,
+		Endpoint:    &endpoint,
+		Environment: env,
 	}
 
 	// Put all metric names in a map so we can quickly look them up to know which metrics should be stored and which are to be ignored.
@@ -48,6 +50,11 @@ func (pc *PrometheusMetricsCollector) GetId() string {
 // GetEndpoint implements a method from MetricsCollector interface
 func (pc *PrometheusMetricsCollector) GetEndpoint() *collector.Endpoint {
 	return pc.Endpoint
+}
+
+// GetAdditionalEnvironment implements a method from MetricsCollector interface
+func (pc *PrometheusMetricsCollector) GetAdditionalEnvironment() map[string]string {
+	return pc.Environment
 }
 
 // CollectMetrics does the real work of actually connecting to a remote Prometheus endpoint,

--- a/src/github.com/hawkular/hawkular-openshift-agent/collector/metrics_collector.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/collector/metrics_collector.go
@@ -13,6 +13,10 @@ type MetricsCollector interface {
 	// GetEndpoint returns information that describes the remote endpoint.
 	GetEndpoint() *Endpoint
 
+	// GetAdditionalEnvironment provides a map of additional name/value pairs used to expand tokens within tags defined for endpoint metrics.
+	// These are extra name/value pairs that do not include the OS environment which will always be used in addition to the returned map.
+	GetAdditionalEnvironment() map[string]string
+
 	// CollectMetrics connects to the remote endpoint and collects the metrics it finds there.
 	CollectMetrics() ([]hmetrics.MetricHeader, error)
 }

--- a/src/github.com/hawkular/hawkular-openshift-agent/config/tags/config_tags.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/config/tags/config_tags.go
@@ -20,7 +20,8 @@ func (t *Tags) AppendTags(moreTags map[string]string) {
 // ExpandTokens will replace all tag values such that $name or ${name}
 // expressions are replaced with their corresponding values found in either
 // the operating system environment variable table and/or the given
-// additional environment map.
+// additional environment map. The expanded tags map is returned.
+//
 // A default value can be optionally specified in the following manner:
 //    ${name=default}
 // If a default value is not specified, an empty string is used as the default.
@@ -31,9 +32,9 @@ func (t *Tags) AppendTags(moreTags map[string]string) {
 // additionalEnv value will be used to replace the $name token.
 // If a name is not found, the default value is used to replace the $name token.
 // If you want a literal $ in the string, use $$.
-func (t *Tags) ExpandTokens(useOsEnv bool, additionalEnv *map[string]string) {
+func (t *Tags) ExpandTokens(useOsEnv bool, additionalEnv map[string]string) map[string]string {
 	if t == nil {
-		return
+		return map[string]string{}
 	}
 
 	mappingFunc := func(s string) string {
@@ -51,10 +52,8 @@ func (t *Tags) ExpandTokens(useOsEnv bool, additionalEnv *map[string]string) {
 		}
 
 		// Look up the value, first in the additional env map, then in the OS env map
-		if additionalEnv != nil {
-			if val, ok := (*additionalEnv)[s]; ok {
-				return val
-			}
+		if val, ok := additionalEnv[s]; ok {
+			return val
 		}
 
 		if useOsEnv {
@@ -66,7 +65,11 @@ func (t *Tags) ExpandTokens(useOsEnv bool, additionalEnv *map[string]string) {
 		return defaultVal
 	}
 
+	ret := make(map[string]string, len(*t))
+
 	for k, v := range *t {
-		(*t)[k] = os.Expand(v, mappingFunc)
+		ret[k] = os.Expand(v, mappingFunc)
 	}
+
+	return ret
 }

--- a/src/github.com/hawkular/hawkular-openshift-agent/config/tags/config_tags_test.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/config/tags/config_tags_test.go
@@ -38,7 +38,7 @@ func TestExpandWithDefault(t *testing.T) {
 		"tag3": "${THIS_DOES_NOT_EXIST}",
 	}
 
-	tags.ExpandTokens(true, nil)
+	tags = tags.ExpandTokens(true, nil)
 
 	assertTagValue(t, tags, "tag1", envvar1)
 	assertTagValue(t, tags, "tag2", "default value")
@@ -66,7 +66,7 @@ func TestExpandEnvVars(t *testing.T) {
 		"tag8": "$$literal",
 	}
 
-	tags.ExpandTokens(true, nil)
+	tags = tags.ExpandTokens(true, nil)
 
 	assertTagValue(t, tags, "tag0", "tagvalue 0 with no tokens!")
 	assertTagValue(t, tags, "tag1", envvar1)
@@ -82,11 +82,11 @@ func TestExpandEnvVars(t *testing.T) {
 func TestAdditionalValues(t *testing.T) {
 
 	tags := Tags{"tag1": "$not_a_env_var"}
-	tags.ExpandTokens(false, &map[string]string{"not_a_env_var": "some value"})
+	tags = tags.ExpandTokens(false, map[string]string{"not_a_env_var": "some value"})
 	assertTagValue(t, tags, "tag1", "some value")
 
 	tags = Tags{"tag1": "the sum of $one plus $two is ${three}"}
-	tags.ExpandTokens(false, &map[string]string{
+	tags = tags.ExpandTokens(false, map[string]string{
 		"one":    "1",
 		"two":    "2",
 		"three":  "3",
@@ -98,7 +98,7 @@ func TestAdditionalValues(t *testing.T) {
 func TestSpecialCharsInNames(t *testing.T) {
 
 	tags := Tags{"tag1": "pod name is ${POD:Name} p|a = ${p|a}"}
-	tags.ExpandTokens(false, &map[string]string{
+	tags = tags.ExpandTokens(false, map[string]string{
 		"POD:Name": "foo",
 		"p|a":      "bar",
 	})
@@ -111,19 +111,19 @@ func TestOverrideEnvVar(t *testing.T) {
 	os.Setenv("TEST_FIRST_ENVVAR", envvar1)
 
 	tags := Tags{"tag1": "$TEST_FIRST_ENVVAR"}
-	tags.ExpandTokens(true, nil)
+	tags = tags.ExpandTokens(true, nil)
 	assertTagValue(t, tags, "tag1", envvar1)
 
 	tags = Tags{"tag1": "$TEST_FIRST_ENVVAR"}
-	tags.ExpandTokens(false, nil)
+	tags = tags.ExpandTokens(false, nil)
 	assertTagValue(t, tags, "tag1", "")
 
 	tags = Tags{"tag1": "$TEST_FIRST_ENVVAR"}
-	tags.ExpandTokens(true, &map[string]string{"TEST_FIRST_ENVVAR": "override value"})
+	tags = tags.ExpandTokens(true, map[string]string{"TEST_FIRST_ENVVAR": "override value"})
 	assertTagValue(t, tags, "tag1", "override value")
 
 	tags = Tags{"tag1": "$TEST_FIRST_ENVVAR"}
-	tags.ExpandTokens(false, &map[string]string{"TEST_FIRST_ENVVAR": "override value"})
+	tags = tags.ExpandTokens(false, map[string]string{"TEST_FIRST_ENVVAR": "override value"})
 	assertTagValue(t, tags, "tag1", "override value")
 }
 

--- a/src/github.com/hawkular/hawkular-openshift-agent/hawkular-openshift-agent.go
+++ b/src/github.com/hawkular/hawkular-openshift-agent/hawkular-openshift-agent.go
@@ -62,16 +62,6 @@ func main() {
 	}
 	log.Tracef("Hawkular OpenShift Agent Configuration:\n%s", Configuration)
 
-	// replace all ${env} tokens in global tags, all endpoint tags, and all endpoint metric tags
-	Configuration.Tags.ExpandTokens(true, nil)
-	for _, e := range Configuration.Endpoints {
-		e.Tags.ExpandTokens(true, nil)
-		for _, m := range e.Metrics {
-			m.Tags.ExpandTokens(true, nil)
-		}
-	}
-	log.Tracef("Hawkular OpenShift Agent Configuration with tokens expanded in tags:\n%s", Configuration)
-
 	if err := validateConfig(); err != nil {
 		glog.Fatal(err)
 	}


### PR DESCRIPTION
in order to support global tags that can expand tokens with pod-specific data, we need to expand the tokens later in the lifecycle