### PR TITLE
use all caps for acronyms and abbreviations since apparently that is …

### DIFF
--- a/collector/impl/jolokia_metrics_collector.go
+++ b/collector/impl/jolokia_metrics_collector.go
@@ -33,7 +33,7 @@ import (
 )
 
 type JolokiaMetricsCollector struct {
-	Id          string
+	ID          string
 	Identity    *security.Identity
 	Endpoint    *collector.Endpoint
 	Environment map[string]string
@@ -41,7 +41,7 @@ type JolokiaMetricsCollector struct {
 
 func NewJolokiaMetricsCollector(id string, identity security.Identity, endpoint collector.Endpoint, env map[string]string) (mc *JolokiaMetricsCollector) {
 	mc = &JolokiaMetricsCollector{
-		Id:          id,
+		ID:          id,
 		Identity:    &identity,
 		Endpoint:    &endpoint,
 		Environment: env,
@@ -52,7 +52,7 @@ func NewJolokiaMetricsCollector(id string, identity security.Identity, endpoint 
 
 // GetId implements a method from MetricsCollector interface
 func (jc *JolokiaMetricsCollector) GetId() string {
-	return jc.Id
+	return jc.ID
 }
 
 // GetEndpoint implements a method from MetricsCollector interface
@@ -70,7 +70,7 @@ func (jc *JolokiaMetricsCollector) GetAdditionalEnvironment() map[string]string 
 // CollectMetrics implements a method from MetricsCollector interface
 func (jc *JolokiaMetricsCollector) CollectMetrics() (metrics []hmetrics.MetricHeader, err error) {
 
-	url := jc.Endpoint.Url
+	url := jc.Endpoint.URL
 	now := time.Now()
 
 	if len(jc.Endpoint.Metrics) == 0 {
@@ -118,7 +118,7 @@ func (jc *JolokiaMetricsCollector) CollectMetrics() (metrics []hmetrics.MetricHe
 
 			metric := hmetrics.MetricHeader{
 				Type:   jc.Endpoint.Metrics[i].Type,
-				ID:     jc.Endpoint.Metrics[i].Id,
+				ID:     jc.Endpoint.Metrics[i].ID,
 				Tenant: jc.Endpoint.Tenant,
 				Data:   data,
 			}

--- a/collector/impl/prometheus_metrics_collector.go
+++ b/collector/impl/prometheus_metrics_collector.go
@@ -34,7 +34,7 @@ import (
 )
 
 type PrometheusMetricsCollector struct {
-	Id              string
+	ID              string
 	Identity        *security.Identity
 	Endpoint        *collector.Endpoint
 	Environment     map[string]string
@@ -43,7 +43,7 @@ type PrometheusMetricsCollector struct {
 
 func NewPrometheusMetricsCollector(id string, identity security.Identity, endpoint collector.Endpoint, env map[string]string) (mc *PrometheusMetricsCollector) {
 	mc = &PrometheusMetricsCollector{
-		Id:          id,
+		ID:          id,
 		Identity:    &identity,
 		Endpoint:    &endpoint,
 		Environment: env,
@@ -53,7 +53,7 @@ func NewPrometheusMetricsCollector(id string, identity security.Identity, endpoi
 	// Notice the value of the map is the metric ID - this will be the Hawkular Metrics ID when the metric is stored.
 	mc.metricNameIdMap = make(map[string]string, len(endpoint.Metrics))
 	for _, m := range endpoint.Metrics {
-		mc.metricNameIdMap[m.Name] = m.Id
+		mc.metricNameIdMap[m.Name] = m.ID
 	}
 
 	return
@@ -61,7 +61,7 @@ func NewPrometheusMetricsCollector(id string, identity security.Identity, endpoi
 
 // GetId implements a method from MetricsCollector interface
 func (pc *PrometheusMetricsCollector) GetId() string {
-	return pc.Id
+	return pc.ID
 }
 
 // GetEndpoint implements a method from MetricsCollector interface
@@ -81,11 +81,11 @@ func (pc *PrometheusMetricsCollector) CollectMetrics() (metrics []hmetrics.Metri
 
 	client, err := http.GetHttpClient(pc.Identity)
 	if err != nil {
-		err = fmt.Errorf("Failed to create http client for Prometheus endpoint [%v]. err=%v", pc.Endpoint.Url, err)
+		err = fmt.Errorf("Failed to create http client for Prometheus endpoint [%v]. err=%v", pc.Endpoint.URL, err)
 		return
 	}
 
-	url := pc.Endpoint.Url
+	url := pc.Endpoint.URL
 	now := time.Now()
 
 	if len(pc.Endpoint.Metrics) == 0 {
@@ -98,7 +98,7 @@ func (pc *PrometheusMetricsCollector) CollectMetrics() (metrics []hmetrics.Metri
 
 	metricFamilies, err := prometheus.Scrape(url, &pc.Endpoint.Credentials, client)
 	if err != nil {
-		err = fmt.Errorf("Failed to collect Prometheus metrics from [%v]. err=%v", pc.Endpoint.Url, err)
+		err = fmt.Errorf("Failed to collect Prometheus metrics from [%v]. err=%v", pc.Endpoint.URL, err)
 		return
 	}
 

--- a/collector/manager/metrics_collector_manager.go
+++ b/collector/manager/metrics_collector_manager.go
@@ -58,7 +58,7 @@ func (mcm *MetricsCollectorManager) StartCollectingEndpoints(endpoints []collect
 	if endpoints != nil {
 		for _, e := range endpoints {
 			var theCollector collector.MetricsCollector
-			id := e.Url
+			id := e.URL
 			switch e.Type {
 			case collector.ENDPOINT_TYPE_PROMETHEUS:
 				{
@@ -70,7 +70,7 @@ func (mcm *MetricsCollectorManager) StartCollectingEndpoints(endpoints []collect
 				}
 			default:
 				{
-					glog.Warningf("Will not start collecting for endpoint [%v] - unknown endpoint type [%v]", e.Url, e.Type)
+					glog.Warningf("Will not start collecting for endpoint [%v] - unknown endpoint type [%v]", e.URL, e.Type)
 					return
 				}
 			}
@@ -182,7 +182,7 @@ func (mcm *MetricsCollectorManager) declareMetricDefinitions(endpoint *collector
 		metricDefs[i] = hmetrics.MetricDefinition{
 			Tenant: endpoint.Tenant,
 			Type:   metric.Type,
-			ID:     os.Expand(mcm.Config.Collector.Metric_ID_Prefix, mappingFuncWithEnv) + os.Expand(metric.Id, mappingFunc),
+			ID:     os.Expand(mcm.Config.Collector.Metric_ID_Prefix, mappingFuncWithEnv) + os.Expand(metric.ID, mappingFunc),
 			Tags:   map[string]string(allMetricTags),
 		}
 	}

--- a/collector/metrics_endpoint.go
+++ b/collector/metrics_endpoint.go
@@ -41,7 +41,7 @@ const (
 // Tags specified here will be attached to the metric when stored to Hawkular Metrics.
 // USED FOR YAML
 type MonitoredMetric struct {
-	Id   string ",omitempty"
+	ID   string ",omitempty"
 	Name string
 	Type metrics.MetricType
 	Tags tags.Tags ",omitempty"
@@ -55,7 +55,7 @@ type MonitoredMetric struct {
 // USED FOR YAML (see agent config file)
 type Endpoint struct {
 	Type                     EndpointType
-	Url                      string
+	URL                      string
 	Credentials              security.Credentials
 	Collection_Interval_Secs int
 	Tenant                   string
@@ -64,7 +64,7 @@ type Endpoint struct {
 }
 
 func (m *MonitoredMetric) String() string {
-	return fmt.Sprintf("Metric: id=[%v], name=[%v], type=[%v], tags=[%v]", m.Id, m.Name, m.Type, m.Tags)
+	return fmt.Sprintf("Metric: id=[%v], name=[%v], type=[%v], tags=[%v]", m.ID, m.Name, m.Type, m.Tags)
 }
 
 func (e *Endpoint) String() string {
@@ -76,7 +76,7 @@ func (e *Endpoint) String() string {
 		metricStrings[i] = m.String()
 	}
 	return fmt.Sprintf("Endpoint: type=[%v], url=[%v], coll_int=[%v], tenant=[%v], tags=[%v], metrics=[%v]",
-		e.Type, e.Url, e.Collection_Interval_Secs, e.Tenant, e.Tags, metricStrings)
+		e.Type, e.URL, e.Collection_Interval_Secs, e.Tenant, e.Tags, metricStrings)
 }
 
 // ValidateEndpoint will check the endpoint configuration for correctness.
@@ -87,26 +87,26 @@ func (e *Endpoint) ValidateEndpoint() error {
 		return err
 	}
 
-	if e.Url == "" {
+	if e.URL == "" {
 		return fmt.Errorf("Endpoint is missing URL")
 	}
 
 	if e.Type == "" {
-		return fmt.Errorf("Endpoint [%v] is missing a valid type", e.Url)
+		return fmt.Errorf("Endpoint [%v] is missing a valid type", e.URL)
 	}
 
 	for i, m := range e.Metrics {
 		if m.Name == "" {
-			return fmt.Errorf("Endpoint [%v] has a metric without a name", e.Url)
+			return fmt.Errorf("Endpoint [%v] has a metric without a name", e.URL)
 		}
 
 		if m.Type == "" {
-			return fmt.Errorf("Endpoint [%v] metric [%s] is missing its type", e.Url, m.Name)
+			return fmt.Errorf("Endpoint [%v] metric [%s] is missing its type", e.URL, m.Name)
 		}
 
 		// if there is no metric ID given, just use the metric name itself
-		if m.Id == "" {
-			e.Metrics[i].Id = m.Name
+		if m.ID == "" {
+			e.Metrics[i].ID = m.Name
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -56,7 +56,7 @@ const (
 // one may be configured.
 // USED FOR YAML
 type Hawkular_Server struct {
-	Url          string
+	URL          string
 	Tenant       string
 	Credentials  security.Credentials ",omitempty"
 	CA_Cert_File string               ",omitempty"
@@ -81,7 +81,7 @@ type Collector struct {
 // for the agent to monitor anything in OpenShift.
 // USED FOR YAML
 type Kubernetes struct {
-	Master_Url    string ",omitempty"
+	Master_URL    string ",omitempty"
 	Token         string ",omitempty"
 	CA_Cert_File  string ",omitempty"
 	Pod_Namespace string ",omitempty"
@@ -104,7 +104,7 @@ func NewConfig() (c *Config) {
 	c.Identity.Cert_File = getDefaultString(ENV_IDENTITY_CERT_FILE, "")
 	c.Identity.Private_Key_File = getDefaultString(ENV_IDENTITY_PRIVATE_KEY_FILE, "")
 
-	c.Hawkular_Server.Url = getDefaultString(ENV_HS_URL, "http://127.0.0.1:8080")
+	c.Hawkular_Server.URL = getDefaultString(ENV_HS_URL, "http://127.0.0.1:8080")
 	c.Hawkular_Server.Tenant = getDefaultString(ENV_HS_TENANT, "hawkular")
 	// If we are passing the username/password/token via an environment variable from a secret, we need to trim
 	c.Hawkular_Server.Credentials.Username = strings.TrimSpace(getDefaultString(ENV_HS_USERNAME, ""))
@@ -114,7 +114,7 @@ func NewConfig() (c *Config) {
 
 	c.Collector.Minimum_Collection_Interval_Secs = 10
 
-	c.Kubernetes.Master_Url = getDefaultString(ENV_K8S_MASTER_URL, "")
+	c.Kubernetes.Master_URL = getDefaultString(ENV_K8S_MASTER_URL, "")
 	c.Kubernetes.Pod_Namespace = getDefaultString(ENV_K8S_POD_NAMESPACE, "")
 	c.Kubernetes.Pod_Name = getDefaultString(ENV_K8S_POD_NAME, "")
 	c.Kubernetes.Token = getDefaultString(ENV_K8S_TOKEN, "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,7 +38,7 @@ func TestEnvVar(t *testing.T) {
 
 	conf := NewConfig()
 
-	if conf.Hawkular_Server.Url != "http://TestEnvVar:9090" {
+	if conf.Hawkular_Server.URL != "http://TestEnvVar:9090" {
 		t.Error("Hawkular Server URL is wrong")
 	}
 	if conf.Hawkular_Server.Credentials.Token != "abc123" {
@@ -58,7 +58,7 @@ func TestDefaults(t *testing.T) {
 	if conf.Collector.Minimum_Collection_Interval_Secs != 10 {
 		t.Error("Minimum collection interval default is wrong")
 	}
-	if conf.Hawkular_Server.Url != "http://127.0.0.1:8080" {
+	if conf.Hawkular_Server.URL != "http://127.0.0.1:8080" {
 		t.Error("Hawkular Server URL is wrong")
 	}
 	if conf.Hawkular_Server.Tenant != "hawkular" {
@@ -90,7 +90,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 			Minimum_Collection_Interval_Secs: 12345,
 		},
 		Hawkular_Server: Hawkular_Server{
-			Url: "http://server:80",
+			URL: "http://server:80",
 		},
 		Kubernetes: Kubernetes{
 			Pod_Namespace: "TestMarshalUnmarshal namespace",
@@ -98,12 +98,12 @@ func TestMarshalUnmarshal(t *testing.T) {
 		},
 		Endpoints: []collector.Endpoint{
 			{
-				Url:  "http://host:1111/metrics",
+				URL:  "http://host:1111/metrics",
 				Type: collector.ENDPOINT_TYPE_PROMETHEUS,
 				Collection_Interval_Secs: 123,
 			},
 			{
-				Url:  "http://host:2222/jolokia",
+				URL:  "http://host:2222/jolokia",
 				Type: collector.ENDPOINT_TYPE_JOLOKIA,
 				Collection_Interval_Secs: 234,
 			},
@@ -135,7 +135,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	if conf.Collector.Metric_ID_Prefix != "" {
 		t.Errorf("Failed to unmarshal empty metric ID prefix:\n%v", conf)
 	}
-	if conf.Hawkular_Server.Url != "http://server:80" {
+	if conf.Hawkular_Server.URL != "http://server:80" {
 		t.Errorf("Failed to unmarshal server url:\n%v", conf)
 	}
 	if conf.Kubernetes.Pod_Namespace != "TestMarshalUnmarshal namespace" {
@@ -176,7 +176,7 @@ func TestLoadSave(t *testing.T) {
 			},
 		},
 		Hawkular_Server: Hawkular_Server{
-			Url: "http://TestLoadSave:80",
+			URL: "http://TestLoadSave:80",
 		},
 		Kubernetes: Kubernetes{
 			Pod_Namespace: "TestLoadSave namespace",
@@ -184,12 +184,12 @@ func TestLoadSave(t *testing.T) {
 		},
 		Endpoints: []collector.Endpoint{
 			{
-				Url:  "http://host:1111/metrics",
+				URL:  "http://host:1111/metrics",
 				Type: collector.ENDPOINT_TYPE_PROMETHEUS,
 				Collection_Interval_Secs: 123,
 			},
 			{
-				Url:  "http://host:2222/jolokia",
+				URL:  "http://host:2222/jolokia",
 				Type: collector.ENDPOINT_TYPE_JOLOKIA,
 				Collection_Interval_Secs: 234,
 			},
@@ -223,7 +223,7 @@ func TestLoadSave(t *testing.T) {
 	if conf.Collector.Metric_ID_Prefix != "prefix" {
 		t.Errorf("Failed to unmarshal metric ID prefix:\n%v", conf)
 	}
-	if conf.Hawkular_Server.Url != "http://TestLoadSave:80" {
+	if conf.Hawkular_Server.URL != "http://TestLoadSave:80" {
 		t.Errorf("Failed to unmarshal server url:\n%v", conf)
 	}
 	if conf.Kubernetes.Pod_Namespace != "TestLoadSave namespace" {

--- a/k8s/configmap_test.go
+++ b/k8s/configmap_test.go
@@ -88,7 +88,7 @@ func TestYamlText(t *testing.T) {
 		Path:     "/1111",
 		Metrics: []collector.MonitoredMetric{
 			collector.MonitoredMetric{
-				Id:   "metric1id",
+				ID:   "metric1id",
 				Type: hmetrics.Gauge,
 				Name: "metric1",
 				Tags: tags.Tags{
@@ -96,7 +96,7 @@ func TestYamlText(t *testing.T) {
 				},
 			},
 			collector.MonitoredMetric{
-				Id:   "metric2id",
+				ID:   "metric2id",
 				Type: hmetrics.Counter,
 				Name: "metric2",
 			},
@@ -174,7 +174,7 @@ endpoints:
 	if len(cme.Endpoints[0].Metrics) != 2 {
 		t.Fatalf("Endpoint.Metrics length is wrong")
 	}
-	if cme.Endpoints[0].Metrics[0].Id != "metric1id" {
+	if cme.Endpoints[0].Metrics[0].ID != "metric1id" {
 		t.Fatalf("Endpoint.Metrics[0] id is wrong")
 	}
 	if cme.Endpoints[0].Metrics[0].Name != "metric1" {

--- a/k8s/k8s_client.go
+++ b/k8s/k8s_client.go
@@ -31,7 +31,7 @@ func GetKubernetesClient(conf *config.Config) (coreClient *v1.CoreClient, err er
 
 	var restConfig *rest.Config
 
-	url := conf.Kubernetes.Master_Url
+	url := conf.Kubernetes.Master_URL
 	token := conf.Kubernetes.Token
 	caCertFile := conf.Kubernetes.CA_Cert_File
 

--- a/k8s/node_event_consumer.go
+++ b/k8s/node_event_consumer.go
@@ -171,7 +171,7 @@ func (nec *NodeEventConsumer) startCollecting(ne *NodeEvent) {
 		// Note that the tenant for all metrics collected from this endpoint
 		// must be the same as the namespace of the pod where the endpoint is located
 		newEndpoint := &collector.Endpoint{
-			Url:                      url.String(),
+			URL:                      url.String(),
 			Type:                     cmeEndpoint.Type,
 			Tenant:                   ne.Pod.Namespace.Name,
 			Credentials:              cmeEndpoint.Credentials,

--- a/storage/metrics_storage.go
+++ b/storage/metrics_storage.go
@@ -177,7 +177,7 @@ func getHawkularMetricsClient(conf *config.Config) (*hmetrics.Client, error) {
 
 	params := hmetrics.Parameters{
 		Tenant:    conf.Hawkular_Server.Tenant,
-		Url:       conf.Hawkular_Server.Url,
+		Url:       conf.Hawkular_Server.URL,
 		Username:  conf.Hawkular_Server.Credentials.Username,
 		Password:  conf.Hawkular_Server.Credentials.Password,
 		Token:     conf.Hawkular_Server.Credentials.Token,


### PR DESCRIPTION
use all caps for acronyms and abbreviations since apparently that is the Go convention. See:

https://github.com/golang/go/wiki/CodeReviewComments

and

https://talks.golang.org/2014/names.slide#6