### PR TITLE
refactor the collector creator stuff

### DIFF
--- a/collector/manager/metrics_collector_creator.go
+++ b/collector/manager/metrics_collector_creator.go
@@ -1,0 +1,27 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/hawkular/hawkular-openshift-agent/collector"
+	"github.com/hawkular/hawkular-openshift-agent/collector/impl"
+	"github.com/hawkular/hawkular-openshift-agent/config/security"
+)
+
+func CreateMetricsCollector(id string, identity security.Identity, endpoint collector.Endpoint, env map[string]string) (theCollector collector.MetricsCollector, err error) {
+	switch endpoint.Type {
+	case collector.ENDPOINT_TYPE_PROMETHEUS:
+		{
+			theCollector = impl.NewPrometheusMetricsCollector(id, identity, endpoint, env)
+		}
+	case collector.ENDPOINT_TYPE_JOLOKIA:
+		{
+			theCollector = impl.NewJolokiaMetricsCollector(id, identity, endpoint, env)
+		}
+	default:
+		{
+			err = fmt.Errorf("Unknown endpoint type [%v]", endpoint.Type)
+		}
+	}
+	return
+}


### PR DESCRIPTION
So there is only one place that creates the endpoint-specific collector. I suspect in the future we will need to support more types so it will be easier if there is only one place that does the creation of the different impls. Will be easier if we ever implement some type of plugin system, too.