### PR TITLE
Makes the pod naming and labels more consistent with existing metrics.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO_BUILD_ENVVARS = \
 	CGO_ENABLED=0 \
 
 DOCKER_NAME = hawkular/hawkular-openshift-agent
-DOCKER_VERSION = latest
+DOCKER_VERSION = dev
 DOCKER_TAG = ${DOCKER_NAME}:${DOCKER_VERSION}
 
 all: build

--- a/deploy/openshift/hawkular-openshift-agent-configmap.yaml
+++ b/deploy/openshift/hawkular-openshift-agent-configmap.yaml
@@ -10,7 +10,7 @@ data:
   config.yaml: |
     collector:
       minimum_collection_interval_secs: 10
-      metric_id_prefix: ${POD:name}/${POD:uid}/
+      metric_id_prefix: pod/${POD:uid}/custom/
       tags:
         namespace_id: ${POD:namespace_uid}
         namespace_name: ${POD:namespace_name}
@@ -19,5 +19,8 @@ data:
         pod_name: ${POD:name}
         pod_namespace: ${POD:namespace_name}
         hostname: ${POD:hostname}
-        subdomain: ${POD:subdomain}
+        host_id: ${POD:hostname}
         labels: ${POD:labels}
+        type: pod
+        collector: hawkular_openshift_agent
+        custom_metric: true

--- a/deploy/openshift/hawkular-openshift-agent.yaml
+++ b/deploy/openshift/hawkular-openshift-agent.yaml
@@ -5,6 +5,10 @@ name: Hawkular OpenShift Agent Template
 metadata:
   name: hawkular-openshift-agent
   metrics-infra: agent
+parameters:
+- description: The version of the image to use
+  name: IMAGE_VERSION
+  value: dev
 objects:
 - apiVersion: v1
   kind: ServiceAccount
@@ -32,8 +36,7 @@ objects:
       spec:
         serviceAccount: hawkular-agent
         containers:
-        - image: hawkular/hawkular-openshift-agent:latest
-          imagePullPolicy: Never
+        - image: hawkular/hawkular-openshift-agent:${IMAGE_VERSION}
           name: hawkular-openshift-agent
           command:
             - "/opt/hawkular/hawkular-openshift-agent"


### PR DESCRIPTION
Also makes the container version more configurable. Using 'dev' allows us to remove 'imagePullPolicy' and makes it more clear that its a developer only build and not the latest from the docker registry.