### PR TITLE
Remove sudo from the makefile so the script no longer requires interaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ build:  clean
 	${GO_BUILD_ENVVARS} go build \
 	   -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
-docker: build
+docker:
 	@echo Building Docker Image...
 	@mkdir -p _output/docker
 	@cp -r deploy/docker/* _output/docker
 	@cp hawkular-openshift-agent _output/docker	
-	sudo docker build -t ${DOCKER_TAG} _output/docker
+	docker build -t ${DOCKER_TAG} _output/docker
 
 openshift-deploy: openshift-undeploy
 	@echo Deploying Components to OpenShift


### PR DESCRIPTION
This change removes the 'sudo' command from the Makefile which means it no longer needs to be interactive.

It also removes the build step from the 'docker' option. So now you will need to run 'make; make docker' to rebuild the project and create the docker image.

Note: for individuals who need to have root privileges to run docker, you will just need call 'sudo make docker'