### PR TITLE
Issue 70 refactor discovery

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -184,29 +184,29 @@ K8S_TOKEN=`oc whoami -t` ${GOPATH}/bin/hawkular-openshift-agent -config config.y
 
 == Configuring OpenShift
 
-When Hawkular OpenShift Agent is monitoring resources running on an OpenShift node, it looks at custom annotations and config maps found in OpenShift to know what to monitor. In effect, the pods tell Hawkular OpenShift Agent what to monitor, and Hawkular OpenShift Agent does it. (Note that where "OpenShift" is mentioned, it is normally synonymous with "Kubernetes" because Hawkular OpenShift Agent is really interfacing with the underlying Kubernetes software that is running in OpenShift)
+When Hawkular OpenShift Agent is monitoring resources running on an OpenShift node, it looks at volumes and config maps to know what to monitor. In effect, the pods tell Hawkular OpenShift Agent what to monitor, and Hawkular OpenShift Agent does it. (Note that where "OpenShift" is mentioned, it is normally synonymous with "Kubernetes" because Hawkular OpenShift Agent is really interfacing with the underlying Kubernetes software that is running in OpenShift)
 
 One caveat must be mentioned up front. Hawkular OpenShift Agent will only monitor a single OpenShift node. If you want to monitor multiple OpenShift nodes, you must run one Hawkular OpenShift Agent process per node.
 
-There are two features in OpenShift that Hawkular OpenShift Agent takes advantage of when it comes to configuring what Hawkular OpenShift Agent should be monitoring - one is pod annotations and the second is project config maps.
+There are two features in OpenShift that Hawkular OpenShift Agent takes advantage of when it comes to configuring what Hawkular OpenShift Agent should be monitoring - one is pod volumes and the second is project config maps.
 
-=== Pod Annotations
+=== Pod Volumes
 
-Each pod running on the node has a set of annotations. An annotation is simply a name/value pair. Hawkular OpenShift Agent expects to see an annotation named "hawkular-openshift-agent" on a pod that is to be monitored. If this annotation is missing, it is assumed you do not want Hawkular OpenShift Agent to monitor that pod. The value of this annotation named "hawkular-openshift-agent" is the name of a config map within the pod's project. If the config map is not found in the pod's project, again Hawkular OpenShift Agent will not monitor the pod.
+Each pod running on the node has a set of volumes. A volume can refer to different types of entities with config maps being one such type that cab be referred to by a volume. Hawkular OpenShift Agent expects to see a volume named `hawkular-openshift-agent` on a pod that is to be monitored and it is expected to be referring to a config map. If this named volume is missing, it is assumed you do not want Hawkular OpenShift Agent to monitor that pod. The name of the volume's config map refers to a config map found within the pod's project. If the config map is not found in the pod's project, again Hawkular OpenShift Agent will not monitor the pod.
 
 === Project Config Map
 
 Pods are grouped in what are called "projects" in OpenShift (Kubernetes calls these "namespaces" - if you see "namespace" in the Hawkular OpenShift Agent configuration settings and log messages, realize it is talking about an OpenShift project). Each project has what is called a "config map". Similiar to annotations, config maps contain name/value pairs. The values can be as simple as short strings or as complex as complete YAML or JSON blobs. Because config maps are on projects, they are associated with multiple pods (the pods within the project).
 
-Hawkular OpenShift Agent takes advantage of a project's config maps by using them as places to put YAML configuration for each monitored pod that belongs to the project. Each pod configuration is found in one config map. The config map that Hawkular OpenShift Agent will look for must be named the same as the value found in a pod's "hawkular-openshift-agent" annotation.
+Hawkular OpenShift Agent takes advantage of a project's config maps by using them as places to put YAML configuration for each monitored pod that belongs to the project. Each pod configuration is found in one config map. The config map that Hawkular OpenShift Agent will look for must be named the same as the config map name found in a pod's "hawkular-openshift-agent" volume.
 
 === Config Map Entry Schema
 
 Each Hawkular OpenShift Agent config map must have one and only one entry which must be named "hawkular-openshift-agent". A config map entry is a YAML configuration. The Go representation of the YAML schema is found link:https://github.com/hawkular/hawkular-openshift-agent/blob/master/k8s/configmap_entry.go[here].
 
-So, in short, each OpenShift project (aka Kubernetes namespace) will have multiple config maps each with an entry named "hawkular-openshift-agent" where those entries contain YAML configuration containing information about what should be monitored on a pod. A named config map is referenced by a pod's annotation also called "hawkular-openshift-agent".
+So, in short, each OpenShift project (aka Kubernetes namespace) will have multiple config maps each with an entry named "hawkular-openshift-agent" where those entries contain YAML configuration containing information about what should be monitored on a pod. A named config map is referenced by a pod's volume also called "hawkular-openshift-agent".
 
-Hawkular OpenShift Agent examines each pod on the node and by cross-referencing the pod annotations with the project config maps, Hawkular OpenShift Agent knows what it should manage.
+Hawkular OpenShift Agent examines each pod on the node and by cross-referencing the pod volumes with the project config maps, Hawkular OpenShift Agent knows what it should manage.
 
 === Example
 
@@ -231,7 +231,7 @@ data:
       path: /metrics
 ----
 
-Notice the name given to this config map - "my-web-pod-config". This is the name of the config map, and it is this name that should appear as a value to the "hawkular-openshift-agent" annotation found on the "web-pod" pod. It identifies this config map to Hawkular OpenShift Agent as the one that should be used by that pod. Notice also that the name of the config map entry is fixed and must always be "hawkular-openshift-agent". Next, notice the config map entry here. This defines what are to be monitored. Here you see there is a single endpoint for this pod that will expose Prometheus metrics over http and port 8080 at /metrics. The IP address used will be that of the pod itself and thus need not be specified.
+Notice the name given to this config map - "my-web-pod-config". This is the name of the config map, and it is this name that should appear as a value to the "hawkular-openshift-agent" volume found on the "web-pod" pod. It identifies this config map to Hawkular OpenShift Agent as the one that should be used by that pod. Notice also that the name of the config map entry is fixed and must always be "hawkular-openshift-agent". Next, notice the config map entry here. This defines what are to be monitored. Here you see there is a single endpoint for this pod that will expose Prometheus metrics over http and port 8080 at /metrics. The IP address used will be that of the pod itself and thus need not be specified.
 
 To create this config map, save that YAML to a file and use "oc":
 
@@ -247,22 +247,22 @@ If you have already created a "my-web-pod-config" config map on your project, yo
 oc replace -f my-web-pod-config-map.yaml
 ----
 
-Now that the config map has been created on your project, you can now add the annotation to the pods that you want to be monitored with the information in that config map. Let's tell Hawkular OpenShift Agent to monitor pod "web-pod" using the configuration named "my-web-pod-config" found in the config map we just created above. We could do something similar for the app-pod (that is, create a config map named, say, "my-app-pod-config" and annotate the app-pod to point to that config map). This can be done with the "oc" command as well.
+Now that the config map has been created on your project, you can now add the volumes to the pods that you want to be monitored with the information in that config map. Let's tell Hawkular OpenShift Agent to monitor pod "web-pod" using the configuration named "my-web-pod-config" found in the config map we just created above. We could do something similar for the app-pod (that is, create a config map named, say, "my-app-pod-config" and create a volume on the app-pod to point to that config map). You do this by editing your pod configuration and redeploying your pod.
 
-[source,shell]
+[source,yaml]
 ----
-oc annotate --overwrite pods web-pod hawkular-openshift-agent=my-web-pod-config
-oc annotate --overwrite pods app-pod hawkular-openshift-agent=my-app-pod-config
+...
+spec:
+  volumes:
+    - name: hawkular-openshift-agent
+      configMap:
+        name: my-web-pod-config
+...
 ----
 
-Because we do not want to monitor the db-pod, we do not create that annotation on it. This tells Hawkular OpenShift Agent to ignore that pod.
+Because we do not want to monitor the db-pod, we do not create a volume for it. This tells Hawkular OpenShift Agent to ignore that pod.
 
-If you want Hawkular OpenShift Agent to stop monitoring a pod, it is as simple as removing the pod's "hawkular-openshift-agent" annotation:
-
-[source,shell]
-----
-oc annotate pods app-pod hawkular-openshift-agent-
-----
+If you want Hawkular OpenShift Agent to stop monitoring a pod, it is as simple as removing the pod's "hawkular-openshift-agent" volume but you will need to redeploy the pod. Alternatively, if you do not want to destroy and recreate your pod, you can edit your config map and remove all endpoints thus the agent will have nothing to monitor.
 
 === Try It!
 
@@ -615,6 +615,18 @@ Tag values can be defined with token expressions in the form of `${var}` or `$va
 
 |POD:labels
 |The Pod labels concatenated in a single string separated by commas, e.g. `label1:value1,label2:value2,...`
+
+|METRIC:name
+|The name of the metric on which this tag is found.
+
+|METRIC:id
+|The id of the metric on which this tag is found.
+
+|METRIC:units
+|The units of measurement for the metric data if applicable. This will be things like 'ms', 'GB', etc. This can be determined from the endpoint itself (if available) or defined within the YAML metric declaration.
+
+|METRIC:description
+|Describes the metric on which this tag is found. This can be determined from the endpoint itself (if available) or defined within the YAML metric declaration.
 |===
 
 For example:

--- a/collector/manager/metrics_collector_manager.go
+++ b/collector/manager/metrics_collector_manager.go
@@ -72,7 +72,13 @@ func (mcm *MetricsCollectorManager) StartCollectingEndpoints(endpoints []collect
 // If a metrics collector with the same ID is already collecting metrics, it will be stopped
 // and the given new collector will take its place.
 func (mcm *MetricsCollectorManager) StartCollecting(theCollector collector.MetricsCollector) {
+
 	id := theCollector.GetId()
+
+	if theCollector.GetEndpoint().IsEnabled() == false {
+		glog.Infof("Will not collect metrics from [%v] - it has been disabled.", id)
+		return
+	}
 
 	// if there was an old ticker still running for this collector, stop it
 	mcm.StopCollecting(id)

--- a/collector/metrics_endpoint.go
+++ b/collector/metrics_endpoint.go
@@ -57,6 +57,7 @@ type MonitoredMetric struct {
 // USED FOR YAML (see agent config file)
 type Endpoint struct {
 	Type                     EndpointType
+	Enabled                  string
 	URL                      string
 	Credentials              security.Credentials
 	Collection_Interval_Secs int
@@ -69,6 +70,14 @@ func (m *MonitoredMetric) String() string {
 	return fmt.Sprintf("Metric: id=[%v], name=[%v], type=[%v], units=[%v], tags=[%v]", m.ID, m.Name, m.Type, m.Units, m.Tags)
 }
 
+// IsEnabled returns true if this endpoint has been enabled; false otherwise.
+func (e *Endpoint) IsEnabled() bool {
+	if e.Enabled == "" || e.Enabled == "true" {
+		return true
+	}
+	return false
+}
+
 func (e *Endpoint) String() string {
 	if e == nil {
 		return ""
@@ -77,8 +86,8 @@ func (e *Endpoint) String() string {
 	for i, m := range e.Metrics {
 		metricStrings[i] = m.String()
 	}
-	return fmt.Sprintf("Endpoint: type=[%v], url=[%v], coll_int=[%v], tenant=[%v], tags=[%v], metrics=[%v]",
-		e.Type, e.URL, e.Collection_Interval_Secs, e.Tenant, e.Tags, metricStrings)
+	return fmt.Sprintf("Endpoint: type=[%v], enabled=[%v], url=[%v], coll_int=[%v], tenant=[%v], tags=[%v], metrics=[%v]",
+		e.Type, e.Enabled, e.URL, e.Collection_Interval_Secs, e.Tenant, e.Tags, metricStrings)
 }
 
 // ValidateEndpoint will check the endpoint configuration for correctness.
@@ -99,6 +108,10 @@ func (e *Endpoint) ValidateEndpoint() error {
 		if e.Type != ENDPOINT_TYPE_JOLOKIA && e.Type != ENDPOINT_TYPE_PROMETHEUS {
 			return fmt.Errorf("Endpoint [%v] has invalid type [%v]", e.URL, e.Type)
 		}
+	}
+
+	if e.Enabled != "" && e.Enabled != "true" && e.Enabled != "false" {
+		return fmt.Errorf("Endpoint [%v] has invalid enabled flag [%v] - must be 'true' or 'false'", e.URL, e.Enabled)
 	}
 
 	for i, m := range e.Metrics {

--- a/hack/jolokia-wildfly-example/jolokia-wildfly.yaml
+++ b/hack/jolokia-wildfly-example/jolokia-wildfly.yaml
@@ -20,9 +20,11 @@ objects:
       metadata:
         labels:
           name: jolokia-wildfly
-        annotations:
-          hawkular-openshift-agent: jolokia-wildfly
       spec:
         containers:
         - image: jmazzitelli/jolokia-wildfly
           name: jolokia-wildfly
+        volumes:
+        - name: hawkular-openshift-agent
+          configMap:
+            name: jolokia-wildfly

--- a/hack/prometheus-python-example/prometheus-python.yaml
+++ b/hack/prometheus-python-example/prometheus-python.yaml
@@ -28,12 +28,14 @@ objects:
         labels:
           name: prometheus-python-example
           hawkular-openshift-agent-example: prometheus-python
-        annotations:
-          hawkular-openshift-agent: prometheus-python-example
       spec:
         containers:
         - image: hawkular/openshift-agent-example-prometheus-python:${IMAGE_VERSION}
           name: prometheus-python-example
+        volumes:
+        - name: hawkular-openshift-agent
+          configMap:
+            name: prometheus-python-example
 - apiVersion: v1
   kind: ConfigMap
   metadata:

--- a/k8s/configmap_test.go
+++ b/k8s/configmap_test.go
@@ -30,6 +30,7 @@ func TestConfigMapEntryYamlNilTags(t *testing.T) {
 	yaml1 := `
 endpoints:
 - type: prometheus
+  enabled: true
   protocol: https
   port: 8888
   path: /the/path
@@ -46,6 +47,12 @@ endpoints:
 
 	if cme.Endpoints[0].Type != collector.ENDPOINT_TYPE_PROMETHEUS {
 		t.Fatalf("Endpoint.Type is wrong")
+	}
+	if cme.Endpoints[0].Enabled != "true" {
+		t.Fatalf("Endpoint.Enabled should be true")
+	}
+	if cme.Endpoints[0].IsEnabled() != true {
+		t.Fatalf("Endpoint.IsEnabled should be true")
 	}
 	if cme.Endpoints[0].Tags == nil {
 		t.Fatalf("Endpoint tags should not be nil")
@@ -82,10 +89,11 @@ func TestYamlText(t *testing.T) {
 	cme := NewConfigMapEntry()
 	cme.Endpoints = append(cme.Endpoints, K8SEndpoint{
 		Collection_Interval_Secs: 123,
-		Type:     collector.ENDPOINT_TYPE_PROMETHEUS,
-		Protocol: K8S_ENDPOINT_PROTOCOL_HTTP,
-		Port:     1111,
-		Path:     "/1111",
+		Enabled:                  "false",
+		Type:                     collector.ENDPOINT_TYPE_PROMETHEUS,
+		Protocol:                 K8S_ENDPOINT_PROTOCOL_HTTP,
+		Port:                     1111,
+		Path:                     "/1111",
 		Metrics: []collector.MonitoredMetric{
 			collector.MonitoredMetric{
 				ID:   "metric1id",
@@ -109,6 +117,10 @@ func TestYamlText(t *testing.T) {
 		Path:     "/2222",
 		Collection_Interval_Secs: 123,
 	})
+
+	if cme.Endpoints[0].IsEnabled() != false {
+		t.Fatalf("Should have been disabled: %v", cme)
+	}
 
 	// I just want to see what happens if you don't specify the metrics slice in the second endpoint
 	if len(cme.Endpoints[0].Metrics) != 2 {
@@ -158,6 +170,12 @@ endpoints:
 
 	if cme.Endpoints[0].Type != collector.ENDPOINT_TYPE_PROMETHEUS {
 		t.Fatalf("Endpoint.Type is wrong")
+	}
+	if cme.Endpoints[0].Enabled != "true" {
+		t.Fatalf("Endpoint.Enabled is wrong - its default should be true")
+	}
+	if cme.Endpoints[0].IsEnabled() != true {
+		t.Fatalf("Endpoint.IsEnabled is wrong - its default should be true")
 	}
 	if cme.Endpoints[0].Protocol != K8S_ENDPOINT_PROTOCOL_HTTPS {
 		t.Fatalf("Endpoint.Protocol is wrong")

--- a/k8s/node_event_consumer.go
+++ b/k8s/node_event_consumer.go
@@ -168,6 +168,11 @@ func (nec *NodeEventConsumer) startCollecting(ne *NodeEvent) {
 			continue
 		}
 
+		if cmeEndpoint.IsEnabled() == false {
+			glog.Infof("Will not start collecting for endpoint [%v] in pod [%v] - it has been disabled.", url, ne.Pod.GetIdentifier())
+			continue
+		}
+
 		// Define additional envvars with pod specific data for use in replacing ${env} tokens.
 		// These tokens are used in tags and in the Tenant field.
 		additionalEnv := map[string]string{
@@ -194,6 +199,7 @@ func (nec *NodeEventConsumer) startCollecting(ne *NodeEvent) {
 		newEndpoint := &collector.Endpoint{
 			URL:                      url.String(),
 			Type:                     cmeEndpoint.Type,
+			Enabled:                  cmeEndpoint.Enabled,
 			Tenant:                   endpointTenant,
 			Credentials:              cmeEndpoint.Credentials,
 			Collection_Interval_Secs: cmeEndpoint.Collection_Interval_Secs,

--- a/k8s/pod.go
+++ b/k8s/pod.go
@@ -22,16 +22,17 @@ import (
 )
 
 type Pod struct {
-	Node        Node
-	Namespace   Namespace
-	Name        string
-	UID         string
-	PodIP       string
-	HostIP      string
-	Hostname    string
-	Subdomain   string
-	Labels      map[string]string
-	Annotations map[string]string
+	Node             Node
+	Namespace        Namespace
+	Name             string
+	UID              string
+	PodIP            string
+	HostIP           string
+	Hostname         string
+	Subdomain        string
+	Labels           map[string]string
+	Annotations      map[string]string
+	ConfigMapVolumes map[string]string
 }
 
 // Identifier returns a string smaller than String() but can still uniquely identify the pod
@@ -40,6 +41,6 @@ func (p *Pod) GetIdentifier() string {
 }
 
 func (p *Pod) String() string {
-	return fmt.Sprintf("Pod: [%v], pod-ip=[%v], host-ip=[%v], subdomain=[%v], hostname=[%v], labels=[%v], annotations=[%v]",
-		p.GetIdentifier(), p.PodIP, p.HostIP, p.Subdomain, p.Hostname, p.Labels, p.Annotations)
+	return fmt.Sprintf("Pod: [%v], pod-ip=[%v], host-ip=[%v], subdomain=[%v], hostname=[%v], labels=[%v], annotations=[%v], config-map-volumes=[%v]",
+		p.GetIdentifier(), p.PodIP, p.HostIP, p.Subdomain, p.Hostname, p.Labels, p.Annotations, p.ConfigMapVolumes)
 }


### PR DESCRIPTION
Discover what config maps are to be used for which pods by examining volumes, not annotations.

This also introduces an "Enabled" flag under each endpoint definition. If not specified, the endpoint Enabled flag defaults to true. If you explicitly set it to false, collection from that endpoint will stop.