### PR TITLE
issue #73 allow agent configuration to say what the tenant is for pod endpoints

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -521,6 +521,15 @@ kubernetes:
   ca_cert_file: VALUE
 ----
 |File that contains the certificate required to connect to the OpenShift master.
+
+|K8S_TENANT
+|
+[source,yaml]
+----
+kubernetes:
+  tenant: VALUE
+----
+|If defined, this will be the tenant where all pod metrics are stored. If not defined, the default is the tenant specified in the Hawkular_Server section. If defined, may include ${var} tokens where `var` is either an agent environment variable of one of the valid POD tag tokens such as `POD:namespace_name`.
 |===
 
 == Metric Tags

--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,7 @@ const (
 	ENV_K8S_POD_NAME      = "K8S_POD_NAME"
 	ENV_K8S_TOKEN         = "K8S_TOKEN"
 	ENV_K8S_CA_CERT_FILE  = "K8S_CA_CERT_FILE"
+	ENV_K8S_TENANT        = "K8S_TENANT"
 )
 
 // Hawkular_Server defines where the Hawkular Server is. This is where metrics are stored.
@@ -79,6 +80,11 @@ type Collector struct {
 // running in OpenShift) or should identify any pod in the node to be monitored by the agent
 // (if the agent is not running in OpenShift). Pod_Namespace should be empty if you do not wish
 // for the agent to monitor anything in OpenShift.
+// If Tenant is supplied, all metrics collected from all pods will have this tenant.
+// You can specify ${x} tokens in the value for Tenant, such as ${some_env} or one of the POD
+// tokens such as ${POD:namespace_name} which means all metrics will be stored under a tenant
+// that is the same name of the pod namespace where the metric was collected.
+// If Tenant is not supplied, the default is the Tenant defined in the Hawkular_Server section.
 // USED FOR YAML
 type Kubernetes struct {
 	Master_URL    string ",omitempty"
@@ -86,6 +92,7 @@ type Kubernetes struct {
 	CA_Cert_File  string ",omitempty"
 	Pod_Namespace string ",omitempty"
 	Pod_Name      string ",omitempty"
+	Tenant        string ",omitempty"
 }
 
 // Config defines the agent's full YAML configuration.
@@ -119,6 +126,7 @@ func NewConfig() (c *Config) {
 	c.Kubernetes.Pod_Name = getDefaultString(ENV_K8S_POD_NAME, "")
 	c.Kubernetes.Token = getDefaultString(ENV_K8S_TOKEN, "")
 	c.Kubernetes.CA_Cert_File = getDefaultString(ENV_K8S_CA_CERT_FILE, "")
+	c.Kubernetes.Tenant = getDefaultString(ENV_K8S_TENANT, "")
 
 	return
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,10 +31,12 @@ func TestEnvVar(t *testing.T) {
 	defer os.Setenv(ENV_HS_TOKEN, os.Getenv(ENV_HS_TOKEN))
 	defer os.Setenv(ENV_K8S_POD_NAMESPACE, os.Getenv(ENV_K8S_POD_NAMESPACE))
 	defer os.Setenv(ENV_K8S_POD_NAME, os.Getenv(ENV_K8S_POD_NAME))
+	defer os.Setenv(ENV_K8S_TENANT, os.Getenv(ENV_K8S_TENANT))
 	os.Setenv(ENV_HS_URL, "http://TestEnvVar:9090")
 	os.Setenv(ENV_HS_TOKEN, "abc123")
 	os.Setenv(ENV_K8S_POD_NAMESPACE, "TestEnvVar pod namespace")
 	os.Setenv(ENV_K8S_POD_NAME, "TestEnvVar pod name")
+	os.Setenv(ENV_K8S_TENANT, "${POD:namespace_name}")
 
 	conf := NewConfig()
 
@@ -49,6 +51,9 @@ func TestEnvVar(t *testing.T) {
 	}
 	if conf.Kubernetes.Pod_Name != "TestEnvVar pod name" {
 		t.Error("Pod name is wrong")
+	}
+	if conf.Kubernetes.Tenant != "${POD:namespace_name}" {
+		t.Error("Tenant is wrong")
 	}
 }
 
@@ -78,6 +83,9 @@ func TestDefaults(t *testing.T) {
 	}
 	if conf.Kubernetes.Pod_Name != "" {
 		t.Error("Pod name is wrong")
+	}
+	if conf.Kubernetes.Tenant != "" {
+		t.Error("Tenant is wrong")
 	}
 	if len(conf.Endpoints) != 0 {
 		t.Error("There should be no endpoints by default")
@@ -181,6 +189,7 @@ func TestLoadSave(t *testing.T) {
 		Kubernetes: Kubernetes{
 			Pod_Namespace: "TestLoadSave namespace",
 			Pod_Name:      "TestLoadSave name",
+			Tenant:        "${POD:namespace_name}",
 		},
 		Endpoints: []collector.Endpoint{
 			{
@@ -231,6 +240,9 @@ func TestLoadSave(t *testing.T) {
 	}
 	if conf.Kubernetes.Pod_Name != "TestLoadSave name" {
 		t.Error("Pod name is wrong")
+	}
+	if conf.Kubernetes.Tenant != "${POD:namespace_name}" {
+		t.Error("Tenant is wrong")
 	}
 	if conf.Endpoints[0].Collection_Interval_Secs != 123 {
 		t.Error("First endpoint is not correct")

--- a/deploy/openshift/hawkular-openshift-agent-configmap.yaml
+++ b/deploy/openshift/hawkular-openshift-agent-configmap.yaml
@@ -8,6 +8,8 @@ metadata:
     metrics-infra: agent
 data:
   config.yaml: |
+    kubernetes:
+      tenant: ${POD:namespace_name}
     collector:
       minimum_collection_interval_secs: 10
       metric_id_prefix: pod/${POD:uid}/custom/


### PR DESCRIPTION
We typically want pod metrics to be stored in tenants whose names match the pod namespaces where the metrics come from since it matches how the current heapster implementation stores its metrics.

However, some people may not want this and want to define their own tenant(s). See issue #73 . This PR implements this feature.
