### PR TITLE
issue #81 fix the bug where collections stop at wrong time

### DIFF
--- a/k8s/discovery.go
+++ b/k8s/discovery.go
@@ -165,14 +165,27 @@ func (d *Discovery) sendNodeEventDueToChangedConfigMap(namespace string, name st
 		var cme *ConfigMapEntry
 
 		if cm != nil {
+			// the config map changed
 			configMapName, hasVol := p.ConfigMapVolumes[HAWKULAR_OPENSHIFT_AGENT_VOLUME_NAME]
 			if hasVol == true && configMapName == cm.Name {
 				cme = cm.Entry
-				log.Debugf("Configmap [%v] for namespace [%v] affects pod [%v] with volume: [%v=%v]",
+				log.Debugf("Changed configmap [%v] for namespace [%v] affects pod [%v] with volume: [%v=%v]",
 					cm.Name, namespace, p.GetIdentifier(), HAWKULAR_OPENSHIFT_AGENT_VOLUME_NAME, configMapName)
 			} else {
-				log.Debugf("Configmap [%v] for namespace [%v] does not affect pod [%v]",
+				log.Debugf("Changed configmap [%v] for namespace [%v] does not affect pod [%v]",
 					cm.Name, namespace, p.GetIdentifier())
+				return true
+			}
+		} else {
+			// the config map was deleted
+			configMapName, hasVol := p.ConfigMapVolumes[HAWKULAR_OPENSHIFT_AGENT_VOLUME_NAME]
+			if hasVol == true && configMapName == name {
+				log.Debugf("Deleted configmap [%v] for namespace [%v] affects pod [%v] with volume: [%v=%v]",
+					name, namespace, p.GetIdentifier(), HAWKULAR_OPENSHIFT_AGENT_VOLUME_NAME, configMapName)
+			} else {
+				log.Debugf("Deleted configmap [%v] for namespace [%v] does not affect pod [%v]",
+					name, namespace, p.GetIdentifier())
+				return true
 			}
 		}
 


### PR DESCRIPTION
when unrelated config maps are changed or deleted, pod collections were stopping erroneously. this fixes that problem. Not sure what other edge cases we missed, but this takes care of the two problems I saw (editing a config map stopped collections of all endpoints on all pods in the namespace where the config map was; same with deleting a config map).