### PR TITLE
be able to more fully configure the http client

### DIFF
--- a/collector/impl/jolokia_metrics_collector.go
+++ b/collector/impl/jolokia_metrics_collector.go
@@ -19,6 +19,7 @@ package impl
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -80,7 +81,13 @@ func (jc *JolokiaMetricsCollector) CollectMetrics() (metrics []hmetrics.MetricHe
 
 	log.Debugf("Told to collect [%v] Jolokia metrics from [%v]", len(jc.Endpoint.Metrics), url)
 
-	httpClient, err := http.GetHttpClient(jc.Identity)
+	httpConfig := http.HttpClientConfig{
+		Identity: jc.Identity,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: jc.Endpoint.TLS.Skip_Certificate_Validation,
+		},
+	}
+	httpClient, err := httpConfig.BuildHttpClient()
 	if err != nil {
 		err = fmt.Errorf("Failed to create http client for Jolokia endpoint [%v]. err=%v", url, err)
 		return

--- a/collector/impl/prometheus_metrics_collector.go
+++ b/collector/impl/prometheus_metrics_collector.go
@@ -19,6 +19,7 @@ package impl
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -78,7 +79,13 @@ func (pc *PrometheusMetricsCollector) GetAdditionalEnvironment() map[string]stri
 // CollectMetrics implements a method from MetricsCollector interface
 func (pc *PrometheusMetricsCollector) CollectMetrics() (metrics []hmetrics.MetricHeader, err error) {
 
-	client, err := http.GetHttpClient(pc.Identity)
+	httpConfig := http.HttpClientConfig{
+		Identity: pc.Identity,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: pc.Endpoint.TLS.Skip_Certificate_Validation,
+		},
+	}
+	client, err := httpConfig.BuildHttpClient()
 	if err != nil {
 		err = fmt.Errorf("Failed to create http client for Prometheus endpoint [%v]. err=%v", pc.Endpoint.URL, err)
 		return
@@ -210,7 +217,13 @@ func (pc *PrometheusMetricsCollector) prepareTagsMap(promLabels []*prom.LabelPai
 // CollectMetricDetails implements a method from MetricsCollector interface
 func (pc *PrometheusMetricsCollector) CollectMetricDetails() (metricDetails []collector.MetricDetails, err error) {
 
-	client, err := http.GetHttpClient(pc.Identity)
+	httpConfig := http.HttpClientConfig{
+		Identity: pc.Identity,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: pc.Endpoint.TLS.Skip_Certificate_Validation,
+		},
+	}
+	client, err := httpConfig.BuildHttpClient()
 	if err != nil {
 		err = fmt.Errorf("Failed to create http client for Prometheus endpoint [%v]. err=%v", pc.Endpoint.URL, err)
 		return

--- a/collector/metrics_endpoint.go
+++ b/collector/metrics_endpoint.go
@@ -54,11 +54,13 @@ type MonitoredMetric struct {
 // If tenant is not supplied, the global tenant ID defined
 // in the global agent configuration file should be used.
 // Tags specified here will be attached to all metrics coming from this endpoint.
+// TLS configures transport layer security if the URL connection uses TLS.
 // USED FOR YAML (see agent config file)
 type Endpoint struct {
 	Type                     EndpointType
 	Enabled                  string
 	URL                      string
+	TLS                      security.TLS
 	Credentials              security.Credentials
 	Collection_Interval_Secs int
 	Tenant                   string

--- a/config/security/config_security.go
+++ b/config/security/config_security.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 Red Hat, Inc. and/or its affiliates
+   Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
    and other contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,13 @@ type Credentials struct {
 	Username string ",omitempty"
 	Password string ",omitempty"
 	Token    string ",omitempty"
+}
+
+// Skip_Certificate_Validation will disable server certificate verification - the client
+// will accept any certificate presented by the server and any host name in that certificate.
+// USED FOR YAML
+type TLS struct {
+	Skip_Certificate_Validation bool ",omitempty"
 }
 
 // ValidateCredentials makes sure that if username is provided, so is password (and vice versa)

--- a/http/http_client_test.go
+++ b/http/http_client_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 Red Hat, Inc. and/or its affiliates
+   Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
    and other contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ package http
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -85,10 +86,16 @@ func TestSecureComm(t *testing.T) {
 	t.Logf("Started test http server: https://%v", testServerHostPort)
 
 	// the client
-	httpClient, err := GetHttpClient(&security.Identity{
-		Cert_File:        testClientCertFile,
-		Private_Key_File: testClientKeyFile,
-	})
+	httpConfig := HttpClientConfig{
+		Identity: &security.Identity{
+			Cert_File:        testClientCertFile,
+			Private_Key_File: testClientKeyFile,
+		},
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	httpClient, err := httpConfig.BuildHttpClient()
 	if err != nil {
 		t.Fatalf("Failed to create http client")
 	}

--- a/jolokia/jolokia_test.go
+++ b/jolokia/jolokia_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 Red Hat, Inc. and/or its affiliates
+   Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
    and other contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,7 +120,8 @@ func TestJolokia(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	httpClient, err := hawkhttp.GetHttpClient(nil)
+	httpConfig := hawkhttp.HttpClientConfig{}
+	httpClient, err := httpConfig.BuildHttpClient()
 
 	reqs := NewJolokiaRequests()
 	reqs.AddRequest(JolokiaRequest{

--- a/k8s/configmap_entry.go
+++ b/k8s/configmap_entry.go
@@ -39,6 +39,7 @@ const (
 // Endpoint describes a place where and what metrics are exposed.
 // Type indicates the kind of metric endpoint (e.g. Prometheus or Jolokia).
 // Protocol defines the communications protocol (e.g. http or https).
+// TLS configures transport layer security if the prptocol uses TLS.
 // Notice that Host is not defined - it will be determined at runtime via the pod configuration.
 // USED FOR YAML
 type K8SEndpoint struct {
@@ -47,6 +48,7 @@ type K8SEndpoint struct {
 	Protocol                 K8SEndpointProtocol
 	Port                     int
 	Path                     string
+	TLS                      security.TLS
 	Credentials              security.Credentials
 	Collection_Interval_Secs int
 	Tags                     tags.Tags

--- a/k8s/configmap_test.go
+++ b/k8s/configmap_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 Red Hat, Inc. and/or its affiliates
+   Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
    and other contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import (
 	hmetrics "github.com/hawkular/hawkular-client-go/metrics"
 
 	"github.com/hawkular/hawkular-openshift-agent/collector"
+	"github.com/hawkular/hawkular-openshift-agent/config/security"
 	"github.com/hawkular/hawkular-openshift-agent/config/tags"
 )
 
@@ -34,6 +35,8 @@ endpoints:
   protocol: https
   port: 8888
   path: /the/path
+  tls:
+    skip_certificate_validation: true
   collection_interval_secs: 12345
   metrics:
   - id: metric1id
@@ -53,6 +56,9 @@ endpoints:
 	}
 	if cme.Endpoints[0].IsEnabled() != true {
 		t.Fatalf("Endpoint.IsEnabled should be true")
+	}
+	if cme.Endpoints[0].TLS.Skip_Certificate_Validation != true {
+		t.Fatalf("Endpoint Accept Any Server should be true")
 	}
 	if cme.Endpoints[0].Tags == nil {
 		t.Fatalf("Endpoint tags should not be nil")
@@ -94,6 +100,9 @@ func TestYamlText(t *testing.T) {
 		Protocol:                 K8S_ENDPOINT_PROTOCOL_HTTP,
 		Port:                     1111,
 		Path:                     "/1111",
+		TLS: security.TLS{
+			Skip_Certificate_Validation: true,
+		},
 		Metrics: []collector.MonitoredMetric{
 			collector.MonitoredMetric{
 				ID:   "metric1id",
@@ -120,6 +129,13 @@ func TestYamlText(t *testing.T) {
 
 	if cme.Endpoints[0].IsEnabled() != false {
 		t.Fatalf("Should have been disabled: %v", cme)
+	}
+
+	if cme.Endpoints[0].TLS.Skip_Certificate_Validation != true {
+		t.Fatalf("First endpoint should accept any server: %v", cme)
+	}
+	if cme.Endpoints[1].TLS.Skip_Certificate_Validation != false {
+		t.Fatalf("Second endpoint should NOT accept any server: %v", cme)
 	}
 
 	// I just want to see what happens if you don't specify the metrics slice in the second endpoint

--- a/k8s/node_event_consumer.go
+++ b/k8s/node_event_consumer.go
@@ -247,6 +247,7 @@ func (nec *NodeEventConsumer) startCollecting(ne *NodeEvent) {
 			Type:                     cmeEndpoint.Type,
 			Enabled:                  cmeEndpoint.Enabled,
 			Tenant:                   endpointTenant,
+			TLS:                      cmeEndpoint.TLS,
 			Credentials:              endpointCredentials,
 			Collection_Interval_Secs: cmeEndpoint.Collection_Interval_Secs,
 			Metrics:                  cmeEndpoint.Metrics,


### PR DESCRIPTION
issue #91 was the reason for this PR. We want the agent to verify server certificates when connecting to metric endpoints, however, we want to be able to turn that off for specific endpoints if we know an endpoint has, say, a self-signed cert.