### PR TITLE
issue #93 - use go duration strings for collection interval and minimum interval

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -225,7 +225,7 @@ data:
   hawkular-openshift-agent: |
     endpoints:
     - type: prometheus
-      collection_interval_secs: 60
+      collection_interval: 60s
       protocol: "http"
       port: 8080
       path: /metrics
@@ -308,7 +308,7 @@ As an example, suppose you want Hawkular OpenShift Agent to scrape metrics from 
 ----
 - type: "prometheus"
   url: "http://yourcorp.com:9090/metrics"
-  collection_interval_secs: 300
+  collection_interval: 5m
 ----
 
 == Prometheus Endpoints
@@ -328,7 +328,7 @@ A full Prometheus endpoint configuration can look like this:
     token: your-bearer-token-here
     #username: your-user
     #password: your-pass
-  collection_interval_secs: 300
+  collection_interval: 1m
   metrics:
   - name: go_memstats_last_gc_time_seconds
     id: gc_time_secs
@@ -367,7 +367,7 @@ A full Jolokia endpoint configuration can look like this:
     token: your-bearer-token-here
     #username: your-user
     #password: your-pass
-  collection_interval_secs: 300
+  collection_interval: 60s
   metrics:
   - name: java.lang:type=Threading#ThreadCount
     type: counter

--- a/collector/metrics_endpoint.go
+++ b/collector/metrics_endpoint.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 Red Hat, Inc. and/or its affiliates
+   Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
    and other contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package collector
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hawkular/hawkular-client-go/metrics"
 
@@ -57,15 +58,15 @@ type MonitoredMetric struct {
 // TLS configures transport layer security if the URL connection uses TLS.
 // USED FOR YAML (see agent config file)
 type Endpoint struct {
-	Type                     EndpointType
-	Enabled                  string
-	URL                      string
-	TLS                      security.TLS
-	Credentials              security.Credentials
-	Collection_Interval_Secs int
-	Tenant                   string
-	Tags                     tags.Tags ",omitempty"
-	Metrics                  []MonitoredMetric
+	Type                EndpointType
+	Enabled             string
+	URL                 string
+	TLS                 security.TLS
+	Credentials         security.Credentials
+	Collection_Interval string
+	Tenant              string
+	Tags                tags.Tags ",omitempty"
+	Metrics             []MonitoredMetric
 }
 
 func (m *MonitoredMetric) String() string {
@@ -89,7 +90,7 @@ func (e *Endpoint) String() string {
 		metricStrings[i] = m.String()
 	}
 	return fmt.Sprintf("Endpoint: type=[%v], enabled=[%v], url=[%v], coll_int=[%v], tenant=[%v], tags=[%v], metrics=[%v]",
-		e.Type, e.Enabled, e.URL, e.Collection_Interval_Secs, e.Tenant, e.Tags, metricStrings)
+		e.Type, e.Enabled, e.URL, e.Collection_Interval, e.Tenant, e.Tags, metricStrings)
 }
 
 // ValidateEndpoint will check the endpoint configuration for correctness.
@@ -135,6 +136,12 @@ func (e *Endpoint) ValidateEndpoint() error {
 		// if there is no metric ID given, just use the metric name itself
 		if m.ID == "" {
 			e.Metrics[i].ID = m.Name
+		}
+	}
+
+	if e.Collection_Interval != "" {
+		if _, err := time.ParseDuration(e.Collection_Interval); err != nil {
+			return fmt.Errorf("Endpoint [%v] has an invalid collection interval. err=%v", e.URL, err)
 		}
 	}
 

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ hawkular_server:
 emitter:
   address: :8081
 collector:
-  minimum_collection_interval_secs: 10
+  minimum_collection_interval: 10s
   tags:
     namespace_id: ${POD:namespace_uid}
     namespace_name: ${POD:namespace_name}
@@ -28,6 +28,7 @@ endpoints:
   - type: prometheus
     enabled: false
     url: http://127.0.0.1:8081/metrics
+    collection_interval: 1m
     metrics:
     - name: hawkular_openshift_agent_metric_data_points_collected
     - name: go_goroutines

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,9 @@ const (
 	ENV_EMITTER_STATUS_ENABLED  = "EMITTER_STATUS_ENABLED"
 	ENV_EMITTER_HEALTH_ENABLED  = "EMITTER_HEALTH_ENABLED"
 	ENV_EMITTER_STATUS_LOG_SIZE = "EMITTER_STATUS_LOG_SIZE"
+
+	ENV_COLLECTOR_MINIMUM_COLL_INTERVAL = "COLLECTOR_MINIMUM_COLLECTION_INTERVAL"
+	ENV_COLLECTOR_DEFAULT_COLL_INTERVAL = "COLLECTOR_DEFAULT_COLLECTION_INTERVAL"
 )
 
 // Hawkular_Server defines where the Hawkular Server is. This is where metrics are stored.
@@ -76,9 +79,10 @@ type Hawkular_Server struct {
 // all metrics collected by the agent.
 // USED FOR YAML
 type Collector struct {
-	Minimum_Collection_Interval_Secs int
-	Tags                             tags.Tags ",omitempty"
-	Metric_ID_Prefix                 string
+	Minimum_Collection_Interval string
+	Default_Collection_Interval string
+	Tags                        tags.Tags ",omitempty"
+	Metric_ID_Prefix            string
 }
 
 // Kubernetes provides all the details necessary to communicate with the Kubernetes system.
@@ -138,7 +142,8 @@ func NewConfig() (c *Config) {
 	c.Hawkular_Server.Credentials.Token = strings.TrimSpace(getDefaultString(ENV_HS_TOKEN, ""))
 	c.Hawkular_Server.CA_Cert_File = getDefaultString(ENV_HS_CA_CERT_FILE, "")
 
-	c.Collector.Minimum_Collection_Interval_Secs = 10
+	c.Collector.Minimum_Collection_Interval = getDefaultString(ENV_COLLECTOR_MINIMUM_COLL_INTERVAL, "10s")
+	c.Collector.Default_Collection_Interval = getDefaultString(ENV_COLLECTOR_DEFAULT_COLL_INTERVAL, "5m")
 
 	c.Kubernetes.Master_URL = getDefaultString(ENV_K8S_MASTER_URL, "")
 	c.Kubernetes.Pod_Namespace = getDefaultString(ENV_K8S_POD_NAMESPACE, "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -80,8 +80,11 @@ func TestEnvVar(t *testing.T) {
 func TestDefaults(t *testing.T) {
 	conf := NewConfig()
 
-	if conf.Collector.Minimum_Collection_Interval_Secs != 10 {
+	if conf.Collector.Minimum_Collection_Interval != "10s" {
 		t.Error("Minimum collection interval default is wrong")
+	}
+	if conf.Collector.Default_Collection_Interval != "5m" {
+		t.Error("Default collection interval default is wrong")
 	}
 	if conf.Hawkular_Server.URL != "http://127.0.0.1:8080" {
 		t.Error("Hawkular Server URL is wrong")
@@ -130,7 +133,8 @@ func TestDefaults(t *testing.T) {
 func TestMarshalUnmarshal(t *testing.T) {
 	testConf := Config{
 		Collector: Collector{
-			Minimum_Collection_Interval_Secs: 12345,
+			Minimum_Collection_Interval: "12345s",
+			Default_Collection_Interval: "98765s",
 		},
 		Hawkular_Server: Hawkular_Server{
 			URL: "http://server:80",
@@ -147,14 +151,14 @@ func TestMarshalUnmarshal(t *testing.T) {
 		},
 		Endpoints: []collector.Endpoint{
 			{
-				URL:  "http://host:1111/metrics",
-				Type: collector.ENDPOINT_TYPE_PROMETHEUS,
-				Collection_Interval_Secs: 123,
+				URL:                 "http://host:1111/metrics",
+				Type:                collector.ENDPOINT_TYPE_PROMETHEUS,
+				Collection_Interval: "123s",
 			},
 			{
-				URL:  "http://host:2222/jolokia",
-				Type: collector.ENDPOINT_TYPE_JOLOKIA,
-				Collection_Interval_Secs: 234,
+				URL:                 "http://host:2222/jolokia",
+				Type:                collector.ENDPOINT_TYPE_JOLOKIA,
+				Collection_Interval: "234s",
 			},
 		},
 	}
@@ -178,8 +182,11 @@ func TestMarshalUnmarshal(t *testing.T) {
 		t.Errorf("Failed to unmarshal: %v", err)
 	}
 
-	if conf.Collector.Minimum_Collection_Interval_Secs != 12345 {
-		t.Errorf("Failed to unmarshal collection interval:\n%v", conf)
+	if conf.Collector.Minimum_Collection_Interval != "12345s" {
+		t.Errorf("Failed to unmarshal min collection interval:\n%v", conf)
+	}
+	if conf.Collector.Default_Collection_Interval != "98765s" {
+		t.Errorf("Failed to unmarshal default collection interval:\n%v", conf)
 	}
 	if conf.Collector.Metric_ID_Prefix != "" {
 		t.Errorf("Failed to unmarshal empty metric ID prefix:\n%v", conf)
@@ -193,10 +200,10 @@ func TestMarshalUnmarshal(t *testing.T) {
 	if conf.Kubernetes.Pod_Name != "TestMarshalUnmarshal name" {
 		t.Error("Pod name is wrong")
 	}
-	if conf.Endpoints[0].Collection_Interval_Secs != 123 {
+	if conf.Endpoints[0].Collection_Interval != "123s" {
 		t.Error("First endpoint is not correct")
 	}
-	if conf.Endpoints[1].Collection_Interval_Secs != 234 {
+	if conf.Endpoints[1].Collection_Interval != "234s" {
 		t.Error("Second endpoint is not correct")
 	}
 	if conf.Collector.Tags == nil || len(conf.Collector.Tags) > 0 {
@@ -230,8 +237,9 @@ func TestLoadSave(t *testing.T) {
 			Private_Key_File: "/my/key",
 		},
 		Collector: Collector{
-			Minimum_Collection_Interval_Secs: 12345,
-			Metric_ID_Prefix:                 "prefix",
+			Minimum_Collection_Interval: "12345s",
+			Default_Collection_Interval: "98765s",
+			Metric_ID_Prefix:            "prefix",
 			Tags: tags.Tags{
 				"tag1": "tagvalue1",
 				"tag2": "tagvalue2",
@@ -254,14 +262,14 @@ func TestLoadSave(t *testing.T) {
 		},
 		Endpoints: []collector.Endpoint{
 			{
-				URL:  "http://host:1111/metrics",
-				Type: collector.ENDPOINT_TYPE_PROMETHEUS,
-				Collection_Interval_Secs: 123,
+				URL:                 "http://host:1111/metrics",
+				Type:                collector.ENDPOINT_TYPE_PROMETHEUS,
+				Collection_Interval: "123s",
 			},
 			{
-				URL:  "http://host:2222/jolokia",
-				Type: collector.ENDPOINT_TYPE_JOLOKIA,
-				Collection_Interval_Secs: 234,
+				URL:                 "http://host:2222/jolokia",
+				Type:                collector.ENDPOINT_TYPE_JOLOKIA,
+				Collection_Interval: "234s",
 			},
 		},
 	}
@@ -287,8 +295,11 @@ func TestLoadSave(t *testing.T) {
 	if conf.Identity.Private_Key_File != "/my/key" {
 		t.Errorf("Failed to unmarshal identity:\n%v", conf)
 	}
-	if conf.Collector.Minimum_Collection_Interval_Secs != 12345 {
-		t.Errorf("Failed to unmarshal collection interval:\n%v", conf)
+	if conf.Collector.Minimum_Collection_Interval != "12345s" {
+		t.Errorf("Failed to unmarshal min collection interval:\n%v", conf)
+	}
+	if conf.Collector.Default_Collection_Interval != "98765s" {
+		t.Errorf("Failed to unmarshal default collection interval:\n%v", conf)
 	}
 	if conf.Collector.Metric_ID_Prefix != "prefix" {
 		t.Errorf("Failed to unmarshal metric ID prefix:\n%v", conf)
@@ -305,10 +316,10 @@ func TestLoadSave(t *testing.T) {
 	if conf.Kubernetes.Tenant != "${POD:namespace_name}" {
 		t.Error("Tenant is wrong")
 	}
-	if conf.Endpoints[0].Collection_Interval_Secs != 123 {
+	if conf.Endpoints[0].Collection_Interval != "123s" {
 		t.Error("First endpoint is not correct")
 	}
-	if conf.Endpoints[1].Collection_Interval_Secs != 234 {
+	if conf.Endpoints[1].Collection_Interval != "234s" {
 		t.Error("Second endpoint is not correct")
 	}
 	if conf.Collector.Tags["tag1"] != "tagvalue1" {

--- a/deploy/openshift/hawkular-openshift-agent-configmap.yaml
+++ b/deploy/openshift/hawkular-openshift-agent-configmap.yaml
@@ -11,7 +11,8 @@ data:
     kubernetes:
       tenant: ${POD:namespace_name}
     collector:
-      minimum_collection_interval_secs: 10
+      minimum_collection_interval: 10s
+      default_collection_interval: 30s
       metric_id_prefix: pod/${POD:uid}/custom/
       tags:
         metric_name: ${METRIC:name}
@@ -36,7 +37,7 @@ data:
       protocol: "http"
       port: 8080
       path: /metrics
-      collection_interval_secs: 30
+      collection_interval: 30s
       metrics:
       - name: hawkular_openshift_agent_metric_data_points_collected
       - name: process_cpu_seconds_total

--- a/examples/jolokia-wildfly-example/jolokia-wildfly.yaml
+++ b/examples/jolokia-wildfly-example/jolokia-wildfly.yaml
@@ -72,7 +72,7 @@ objects:
         protocol: https
         port: 8778
         path: /jolokia/
-        collection_interval_secs: 15
+        collection_interval: 15s
         tls:
           skip_certificate_validation: true
         credentials:

--- a/examples/prometheus-python-example/prometheus-python.yaml
+++ b/examples/prometheus-python-example/prometheus-python.yaml
@@ -50,7 +50,7 @@ objects:
         protocol: "http"
         port: 8181
         path: /
-        collection_interval_secs: 30
+        collection_interval: 30s
         metrics:
         - name: process_virtual_memory_bytes
           type: gauge

--- a/k8s/configmap_test.go
+++ b/k8s/configmap_test.go
@@ -37,7 +37,7 @@ endpoints:
   path: /the/path
   tls:
     skip_certificate_validation: true
-  collection_interval_secs: 12345
+  collection_interval: 12345s
   metrics:
   - id: metric1id
     name: metric1
@@ -94,12 +94,12 @@ endpoints:
 func TestYamlText(t *testing.T) {
 	cme := NewConfigMapEntry()
 	cme.Endpoints = append(cme.Endpoints, K8SEndpoint{
-		Collection_Interval_Secs: 123,
-		Enabled:                  "false",
-		Type:                     collector.ENDPOINT_TYPE_PROMETHEUS,
-		Protocol:                 K8S_ENDPOINT_PROTOCOL_HTTP,
-		Port:                     1111,
-		Path:                     "/1111",
+		Collection_Interval: "123s",
+		Enabled:             "false",
+		Type:                collector.ENDPOINT_TYPE_PROMETHEUS,
+		Protocol:            K8S_ENDPOINT_PROTOCOL_HTTP,
+		Port:                1111,
+		Path:                "/1111",
 		TLS: security.TLS{
 			Skip_Certificate_Validation: true,
 		},
@@ -120,11 +120,11 @@ func TestYamlText(t *testing.T) {
 		},
 	})
 	cme.Endpoints = append(cme.Endpoints, K8SEndpoint{
-		Type:     collector.ENDPOINT_TYPE_JOLOKIA,
-		Protocol: K8S_ENDPOINT_PROTOCOL_HTTPS,
-		Port:     2222,
-		Path:     "/2222",
-		Collection_Interval_Secs: 123,
+		Type:                collector.ENDPOINT_TYPE_JOLOKIA,
+		Protocol:            K8S_ENDPOINT_PROTOCOL_HTTPS,
+		Port:                2222,
+		Path:                "/2222",
+		Collection_Interval: "123s",
 	})
 
 	if cme.Endpoints[0].IsEnabled() != false {
@@ -162,7 +162,7 @@ endpoints:
   protocol: https
   port: 8888
   path: /the/path
-  collection_interval_secs: 12345
+  collection_interval: 12345s
   tags:
     endpointtagname1: endpointtag1
     endpointtagname2: endpointtag2
@@ -202,7 +202,7 @@ endpoints:
 	if cme.Endpoints[0].Path != "/the/path" {
 		t.Fatalf("Endpoint.Path is wrong")
 	}
-	if cme.Endpoints[0].Collection_Interval_Secs != 12345 {
+	if cme.Endpoints[0].Collection_Interval != "12345s" {
 		t.Fatalf("Endpoint.Collection_Interval is wrong")
 	}
 	if len(cme.Endpoints[0].Metrics) != 2 {
@@ -245,7 +245,7 @@ endpoints:
 	if err != nil {
 		t.Fatalf("Could not unmarshal ConfigMapEntry yaml. err=%v", err)
 	}
-	if cme.Endpoints[0].Collection_Interval_Secs != cme2.Endpoints[0].Collection_Interval_Secs {
+	if cme.Endpoints[0].Collection_Interval != cme2.Endpoints[0].Collection_Interval {
 		t.Fatalf("Marshalling did not produce expected yaml. [%v] != [%v]", cme, cme2)
 	}
 }
@@ -256,7 +256,7 @@ endpoints:
 - type: jolokia
   protocol: https
   port: 8888
-  collection_interval_secs: 12345
+  collection_interval: 12345s
   path: /the/path
   metrics: []
 `

--- a/k8s/configmaps_test.go
+++ b/k8s/configmaps_test.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 Red Hat, Inc. and/or its affiliates
+   Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
    and other contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,20 +26,20 @@ import (
 func TestConfigMaps(t *testing.T) {
 	cme1 := NewConfigMapEntry()
 	cme1.Endpoints = append(cme1.Endpoints, K8SEndpoint{
-		Type:     collector.ENDPOINT_TYPE_JOLOKIA,
-		Protocol: K8S_ENDPOINT_PROTOCOL_HTTPS,
-		Port:     1111,
-		Path:     "/1111",
-		Collection_Interval_Secs: 123,
+		Type:                collector.ENDPOINT_TYPE_JOLOKIA,
+		Protocol:            K8S_ENDPOINT_PROTOCOL_HTTPS,
+		Port:                1111,
+		Path:                "/1111",
+		Collection_Interval: "123s",
 	})
 
 	cme2 := NewConfigMapEntry()
 	cme2.Endpoints = append(cme2.Endpoints, K8SEndpoint{
-		Type:     collector.ENDPOINT_TYPE_PROMETHEUS,
-		Protocol: K8S_ENDPOINT_PROTOCOL_HTTP,
-		Port:     2222,
-		Path:     "/2222",
-		Collection_Interval_Secs: 987,
+		Type:                collector.ENDPOINT_TYPE_PROMETHEUS,
+		Protocol:            K8S_ENDPOINT_PROTOCOL_HTTP,
+		Port:                2222,
+		Path:                "/2222",
+		Collection_Interval: "987s",
 	})
 
 	// put config maps with different names in the same namespace

--- a/k8s/node_event_consumer.go
+++ b/k8s/node_event_consumer.go
@@ -243,15 +243,15 @@ func (nec *NodeEventConsumer) startCollecting(ne *NodeEvent) {
 
 		// We need to convert the k8s endpoint to the generic endpoint struct.
 		newEndpoint := &collector.Endpoint{
-			URL:                      url.String(),
-			Type:                     cmeEndpoint.Type,
-			Enabled:                  cmeEndpoint.Enabled,
-			Tenant:                   endpointTenant,
-			TLS:                      cmeEndpoint.TLS,
-			Credentials:              endpointCredentials,
-			Collection_Interval_Secs: cmeEndpoint.Collection_Interval_Secs,
-			Metrics:                  cmeEndpoint.Metrics,
-			Tags:                     cmeEndpoint.Tags,
+			URL:                 url.String(),
+			Type:                cmeEndpoint.Type,
+			Enabled:             cmeEndpoint.Enabled,
+			Tenant:              endpointTenant,
+			TLS:                 cmeEndpoint.TLS,
+			Credentials:         endpointCredentials,
+			Collection_Interval: cmeEndpoint.Collection_Interval,
+			Metrics:             cmeEndpoint.Metrics,
+			Tags:                cmeEndpoint.Tags,
 		}
 
 		// make sure the endpoint is configured correctly


### PR DESCRIPTION
the collection intervals and minimum collection interval is now specified as strings in the form of Go durations (e.g. "1m" , "30s") etc.