### PR TITLE
Metrics endpoint credentials

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -611,6 +611,26 @@ emitter:
 ----
 |If true, a simple health endpoint is emitted at /health endpoint. This is useful for health probes to check the health of the agent.
 
+|EMITTER_METRICS_CREDENTIALS_USERNAME
+|
+[source,yaml]
+----
+emitter:
+  metrics_credentials:
+    username: VALUE
+----
+|If the metrics emitter is enabled, you can set this username (along with the password) to force users to authenticate themselves in order to see the metrics information.
+
+|EMITTER_METRICS_CREDENTIALS_PASSWORD
+|
+[source,yaml]
+----
+emitter:
+  metrics_credentials:
+    password: VALUE
+----
+|If the metrics emitter is enabled, you can set this password (along with the username) to force users to authenticate themselves in order to see the metrics information.
+
 |EMITTER_STATUS_LOG_SIZE
 |
 [source,yaml]

--- a/config/config.go
+++ b/config/config.go
@@ -51,13 +51,15 @@ const (
 	ENV_K8S_CA_CERT_FILE  = "K8S_CA_CERT_FILE"
 	ENV_K8S_TENANT        = "K8S_TENANT"
 
-	ENV_EMITTER_ADDRESS                     = "EMITTER_ADDRESS"
-	ENV_EMITTER_METRICS_ENABLED             = "EMITTER_METRICS_ENABLED"
-	ENV_EMITTER_STATUS_ENABLED              = "EMITTER_STATUS_ENABLED"
-	ENV_EMITTER_HEALTH_ENABLED              = "EMITTER_HEALTH_ENABLED"
-	ENV_EMITTER_STATUS_LOG_SIZE             = "EMITTER_STATUS_LOG_SIZE"
-	ENV_EMITTER_STATUS_CREDENTIALS_USERNAME = "EMITTER_STATUS_CREDENTIALS_USERNAME"
-	ENV_EMITTER_STATUS_CREDENTIALS_PASSWORD = "EMITTER_STATUS_CREDENTIALS_PASSWORD"
+	ENV_EMITTER_ADDRESS                      = "EMITTER_ADDRESS"
+	ENV_EMITTER_METRICS_ENABLED              = "EMITTER_METRICS_ENABLED"
+	ENV_EMITTER_STATUS_ENABLED               = "EMITTER_STATUS_ENABLED"
+	ENV_EMITTER_HEALTH_ENABLED               = "EMITTER_HEALTH_ENABLED"
+	ENV_EMITTER_METRICS_CREDENTIALS_USERNAME = "EMITTER_METRICS_CREDENTIALS_USERNAME"
+	ENV_EMITTER_METRICS_CREDENTIALS_PASSWORD = "EMITTER_METRICS_CREDENTIALS_PASSWORD"
+	ENV_EMITTER_STATUS_LOG_SIZE              = "EMITTER_STATUS_LOG_SIZE"
+	ENV_EMITTER_STATUS_CREDENTIALS_USERNAME  = "EMITTER_STATUS_CREDENTIALS_USERNAME"
+	ENV_EMITTER_STATUS_CREDENTIALS_PASSWORD  = "EMITTER_STATUS_CREDENTIALS_PASSWORD"
 
 	ENV_COLLECTOR_MINIMUM_COLL_INTERVAL = "COLLECTOR_MINIMUM_COLLECTION_INTERVAL"
 	ENV_COLLECTOR_DEFAULT_COLL_INTERVAL = "COLLECTOR_DEFAULT_COLLECTION_INTERVAL"
@@ -112,12 +114,13 @@ type Kubernetes struct {
 // emitting the agent's own metric data, a status report, and/or the health probe.
 // USED FOR YAML
 type Emitter struct {
-	Metrics_Enabled    string               ",omitempty"
-	Status_Enabled     string               ",omitempty"
-	Health_Enabled     string               ",omitempty"
-	Address            string               ",omitempty"
-	Status_Log_Size    int                  ",omitempty"
-	Status_Credentials security.Credentials ",omitempty"
+	Metrics_Enabled     string               ",omitempty"
+	Status_Enabled      string               ",omitempty"
+	Health_Enabled      string               ",omitempty"
+	Address             string               ",omitempty"
+	Metrics_Credentials security.Credentials ",omitempty"
+	Status_Log_Size     int                  ",omitempty"
+	Status_Credentials  security.Credentials ",omitempty"
 }
 
 // Config defines the agent's full YAML configuration.
@@ -163,6 +166,10 @@ func NewConfig() (c *Config) {
 	c.Emitter.Status_Credentials = security.Credentials{
 		Username: getDefaultString(ENV_EMITTER_STATUS_CREDENTIALS_USERNAME, ""),
 		Password: getDefaultString(ENV_EMITTER_STATUS_CREDENTIALS_PASSWORD, ""),
+	}
+	c.Emitter.Metrics_Credentials = security.Credentials{
+		Username: getDefaultString(ENV_EMITTER_METRICS_CREDENTIALS_USERNAME, ""),
+		Password: getDefaultString(ENV_EMITTER_METRICS_CREDENTIALS_PASSWORD, ""),
 	}
 
 	return

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,6 +35,8 @@ func TestEnvVar(t *testing.T) {
 	defer os.Setenv(ENV_EMITTER_METRICS_ENABLED, os.Getenv(ENV_EMITTER_METRICS_ENABLED))
 	defer os.Setenv(ENV_EMITTER_STATUS_ENABLED, os.Getenv(ENV_EMITTER_STATUS_ENABLED))
 	defer os.Setenv(ENV_EMITTER_HEALTH_ENABLED, os.Getenv(ENV_EMITTER_HEALTH_ENABLED))
+	defer os.Setenv(ENV_EMITTER_METRICS_CREDENTIALS_USERNAME, os.Getenv(ENV_EMITTER_METRICS_CREDENTIALS_USERNAME))
+	defer os.Setenv(ENV_EMITTER_METRICS_CREDENTIALS_PASSWORD, os.Getenv(ENV_EMITTER_METRICS_CREDENTIALS_PASSWORD))
 	defer os.Setenv(ENV_EMITTER_STATUS_LOG_SIZE, os.Getenv(ENV_EMITTER_STATUS_LOG_SIZE))
 	defer os.Setenv(ENV_EMITTER_STATUS_CREDENTIALS_USERNAME, os.Getenv(ENV_EMITTER_STATUS_CREDENTIALS_USERNAME))
 	defer os.Setenv(ENV_EMITTER_STATUS_CREDENTIALS_PASSWORD, os.Getenv(ENV_EMITTER_STATUS_CREDENTIALS_PASSWORD))
@@ -46,6 +48,8 @@ func TestEnvVar(t *testing.T) {
 	os.Setenv(ENV_EMITTER_METRICS_ENABLED, "false")
 	os.Setenv(ENV_EMITTER_STATUS_ENABLED, "true")
 	os.Setenv(ENV_EMITTER_HEALTH_ENABLED, "false")
+	os.Setenv(ENV_EMITTER_METRICS_CREDENTIALS_USERNAME, "m-user")
+	os.Setenv(ENV_EMITTER_METRICS_CREDENTIALS_PASSWORD, "m-pass")
 	os.Setenv(ENV_EMITTER_STATUS_LOG_SIZE, "123")
 	os.Setenv(ENV_EMITTER_STATUS_CREDENTIALS_USERNAME, "user")
 	os.Setenv(ENV_EMITTER_STATUS_CREDENTIALS_PASSWORD, "pass")
@@ -75,6 +79,12 @@ func TestEnvVar(t *testing.T) {
 	}
 	if conf.Emitter.Health_Enabled != "false" {
 		t.Error("Emitter Health Enabled is wrong")
+	}
+	if conf.Emitter.Metrics_Credentials.Username != "m-user" {
+		t.Error("Emitter Status Username is wrong")
+	}
+	if conf.Emitter.Metrics_Credentials.Password != "m-pass" {
+		t.Error("Emitter Status Password is wrong")
 	}
 	if conf.Emitter.Status_Log_Size != 123 {
 		t.Error("Emitter Status Log Size is wrong")
@@ -164,6 +174,10 @@ func TestMarshalUnmarshal(t *testing.T) {
 			Status_Enabled:  "false",
 			Health_Enabled:  "false",
 			Address:         ":12345",
+			Metrics_Credentials: security.Credentials{
+				Username: "m-username",
+				Password: "m-password",
+			},
 			Status_Credentials: security.Credentials{
 				Username: "foo-username",
 				Password: "foo-password",
@@ -248,11 +262,17 @@ func TestMarshalUnmarshal(t *testing.T) {
 	if conf.Emitter.Address != ":12345" {
 		t.Error("Emitter Address is wrong")
 	}
+	if conf.Emitter.Metrics_Credentials.Username != "m-username" {
+		t.Error("Emitter Metrics Credentials Username is wrong")
+	}
+	if conf.Emitter.Metrics_Credentials.Password != "m-password" {
+		t.Error("Emitter Metrics Credentials Password is wrong")
+	}
 	if conf.Emitter.Status_Credentials.Username != "foo-username" {
-		t.Error("Emitter Credentials Username is wrong")
+		t.Error("Emitter Status Credentials Username is wrong")
 	}
 	if conf.Emitter.Status_Credentials.Password != "foo-password" {
-		t.Error("Emitter Credentials Password is wrong")
+		t.Error("Emitter Status Credentials Password is wrong")
 	}
 }
 
@@ -367,16 +387,21 @@ func TestLoadSave(t *testing.T) {
 	if conf.Emitter.Address != ":12345" {
 		t.Error("Emitter Address is wrong")
 	}
+	if conf.Emitter.Metrics_Credentials.Username != "" {
+		t.Error("Emitter Metrics Credentials Username is wrong")
+	}
+	if conf.Emitter.Metrics_Credentials.Password != "" {
+		t.Error("Emitter Metrics Credentials Password is wrong")
+	}
 	if conf.Emitter.Status_Log_Size != 1234 {
 		t.Error("Emitter Status Log Size is wrong")
 	}
 	if conf.Emitter.Status_Credentials.Username != "" {
-		t.Error("Emitter Credentials Username is wrong")
+		t.Error("Emitter Status Credentials Username is wrong")
 	}
 	if conf.Emitter.Status_Credentials.Password != "" {
-		t.Error("Emitter Credentials Password is wrong")
+		t.Error("Emitter Status Credentials Password is wrong")
 	}
-
 }
 
 func TestError(t *testing.T) {

--- a/hawkular-openshift-agent.go
+++ b/hawkular-openshift-agent.go
@@ -173,12 +173,21 @@ func validateConfig() error {
 			Configuration.Emitter.Status_Log_Size)
 	}
 
+	if Configuration.Emitter.Metrics_Enabled == "true" {
+		if err := Configuration.Emitter.Metrics_Credentials.ValidateCredentials(); err != nil {
+			return fmt.Errorf("Emitter metrics credentials are invalid: %v", err)
+		}
+		if Configuration.Emitter.Metrics_Credentials.Token != "" {
+			return fmt.Errorf("Token is not supported for emitter metrics credentials")
+		}
+	}
+
 	if Configuration.Emitter.Status_Enabled == "true" {
 		if err := Configuration.Emitter.Status_Credentials.ValidateCredentials(); err != nil {
-			return fmt.Errorf("Emitter credentials are invalid: %v", err)
+			return fmt.Errorf("Emitter status credentials are invalid: %v", err)
 		}
 		if Configuration.Emitter.Status_Credentials.Token != "" {
-			return fmt.Errorf("Token is not supported for emitter credentials")
+			return fmt.Errorf("Token is not supported for emitter status credentials")
 		}
 		if Configuration.Emitter.Status_Credentials.Username == "" || Configuration.Emitter.Status_Credentials.Password == "" {
 			log.Warning("The status emitter is not secure. It is recommended you secure the status emitter with credentials.")


### PR DESCRIPTION
issue #118 allows you to secure the /metrics endpoint if you want. In the agent config:

```
...
emitter:
  metrics_credentials:
    username: the-username
    password: the-password
...
```

To then collect from the agent's own metrics endpoint:

```
- type: prometheus
    ...
    metrics_credentials:
      username: the-username
      password: the-password
    ...
```