### PR TITLE
BZ1419390: allow the agent to be deployed to another project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,19 +56,19 @@ docker-examples:
 
 openshift-deploy: openshift-undeploy
 	@echo Deploying Components to OpenShift
-	oc create -f deploy/openshift/hawkular-openshift-agent-configmap.yaml -n openshift-infra
-	oc process -f deploy/openshift/hawkular-openshift-agent.yaml -v IMAGE_VERSION=${DOCKER_VERSION} | oc create -n openshift-infra -f -
-	oc create -f deploy/openshift/hawkular-openshift-agent-route.yaml -n openshift-infra
-	oc adm policy add-cluster-role-to-user hawkular-openshift-agent system:serviceaccount:openshift-infra:hawkular-openshift-agent
+	oc create -f deploy/openshift/hawkular-openshift-agent-configmap.yaml -n default
+	oc process -f deploy/openshift/hawkular-openshift-agent.yaml -v IMAGE_VERSION=${DOCKER_VERSION} | oc create -n default -f -
+	oc create -f deploy/openshift/hawkular-openshift-agent-route.yaml -n default
+	oc adm policy add-cluster-role-to-user hawkular-openshift-agent system:serviceaccount:default:hawkular-openshift-agent
 
 openshift-undeploy:
 	@echo Undeploying the Agent from OpenShift
-	oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles --selector=metrics-infra=agent -n openshift-infra
+	oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles --selector=metrics-infra=agent -n default
 	oc delete clusterroles hawkular-openshift-agent
 
 openshift-status:
 	@echo Obtaining Status from the Agent
-	@curl -k -H "Authorization: Basic $(shell echo -n `oc get secret hawkular-openshift-agent-status -n openshift-infra --template='{{.data.username}}' | base64 --decode`:`oc get secret hawkular-openshift-agent-status -n openshift-infra --template='{{.data.password}}' | base64 --decode` | base64)" http://hawkular-openshift-agent-openshift-infra.$(shell oc version | grep 'Server ' | awk '{print $$2;}' | egrep -o '([0-9]{1,3}[.]){3}[0-9]{1,3}').xip.io/status
+	@curl -k -H "Authorization: Basic $(shell echo -n `oc get secret hawkular-openshift-agent-status -n default --template='{{.data.username}}' | base64 --decode`:`oc get secret hawkular-openshift-agent-status -n default --template='{{.data.password}}' | base64 --decode` | base64)" http://hawkular-openshift-agent-default.$(shell oc version | grep 'Server ' | awk '{print $$2;}' | egrep -o '([0-9]{1,3}[.]){3}[0-9]{1,3}').xip.io/status
 
 install:
 	@echo Installing...

--- a/deploy/openshift/hawkular-openshift-agent-configmap.yaml
+++ b/deploy/openshift/hawkular-openshift-agent-configmap.yaml
@@ -10,6 +10,12 @@ data:
   config.yaml: |
     kubernetes:
       tenant: ${POD:namespace_name}
+    hawkular_server:
+      url: https://hawkular-metrics.openshift-infra.svc.cluster.local       
+      credentials:
+        username: secret:openshift-infra/hawkular-metrics-account/hawkular-metrics.username
+        password: secret:openshift-infra/hawkular-metrics-account/hawkular-metrics.password
+      ca_cert_file: secret:openshift-infra/hawkular-metrics-certificate/hawkular-metrics-ca.certificate
     emitter:
       status_enabled: true
     collector:

--- a/deploy/openshift/hawkular-openshift-agent.yaml
+++ b/deploy/openshift/hawkular-openshift-agent.yaml
@@ -93,20 +93,6 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: HAWKULAR_SERVER_URL
-            value: https://hawkular-metrics
-          - name: HAWKULAR_SERVER_CA_CERT_FILE
-            value: "/hawkular-metrics-certificate/hawkular-metrics-ca.certificate"
-          - name: HAWKULAR_SERVER_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: hawkular-metrics-account
-                key: hawkular-metrics.username
-          - name: HAWKULAR_SERVER_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: hawkular-metrics-account
-                key: hawkular-metrics.password
           - name: EMITTER_STATUS_CREDENTIALS_USERNAME
             valueFrom:
               secretKeyRef:
@@ -118,14 +104,9 @@ objects:
                 name: hawkular-openshift-agent-status
                 key: password
           volumeMounts:
-          - name: hawkular-metrics-certificate
-            mountPath: "/hawkular-metrics-certificate"
           - name: hawkular-openshift-agent-configuration
             mountPath: "/hawkular-openshift-agent-configuration"
         volumes:
-        - name: hawkular-metrics-certificate
-          secret:
-            secretName: hawkular-metrics-certificate
         - name: hawkular-openshift-agent-configuration
           configMap:
             name: hawkular-openshift-agent-configuration

--- a/hawkular-openshift-agent.go
+++ b/hawkular-openshift-agent.go
@@ -94,7 +94,7 @@ func main() {
 	// prepare the storage manager and start storing metrics as they come in
 	storageManager, err := storage.NewMetricsStorageManager(Configuration)
 	if err != nil {
-		glog.Fatal("Cannot create storage manager. err=%v", err)
+		glog.Fatalf("Cannot create storage manager. err=%v", err)
 	}
 	storageManager.StartStoringMetrics()
 

--- a/k8s/k8s_client.go
+++ b/k8s/k8s_client.go
@@ -27,6 +27,11 @@ import (
 
 const userAgent string = "Hawkular/Hawkular-OpenShift-Agent"
 
+// IsConfiguredForKubernetes returns true if the agent is to be configured for connection to Kubernetes.
+func IsConfiguredForKubernetes(conf *config.Config) bool {
+	return conf.Kubernetes.Pod_Namespace != ""
+}
+
 func GetKubernetesClient(conf *config.Config) (coreClient *v1.CoreClient, err error) {
 
 	var restConfig *rest.Config

--- a/k8s/node_event_consumer.go
+++ b/k8s/node_event_consumer.go
@@ -55,7 +55,7 @@ func NewNodeEventConsumer(conf *config.Config, mcm *manager.MetricsCollectorMana
 func (nec *NodeEventConsumer) Start() {
 	conf := nec.Config
 
-	if conf.Kubernetes.Pod_Namespace == "" {
+	if !IsConfiguredForKubernetes(conf) {
 		log.Debug("Not configured to monitor within a Kubernetes environment")
 		return
 	}


### PR DESCRIPTION
Allows the agent to be deployed to a different project other than the one where origin-metrics is installed.

This allows us to deploy the agent to the 'default' project where it will be possible to access all pod endpoints if the ovs_multitenant plugin is installed.

The agent requires the credentials and other information from the secrets in the namespace where the origin-metrics pods are deployed. For this we directly access this information from the OpenShift master API and wait until those secrets become available. If they are not available after a timeout, the agent will exit with an error code and restart.