### PR TITLE
introduce new endpoint type: json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ docker-examples:
 	@DOCKER_VERSION=${DOCKER_VERSION} cd examples/jolokia-wildfly-example && make build
 	@echo Building Docker Image of Example: Multiple-Endpoints
 	@DOCKER_VERSION=${DOCKER_VERSION} cd examples/multiple-endpoints-example && make build
+	@echo Building Docker Image of Example: Go-Expvar
+	@DOCKER_VERSION=${DOCKER_VERSION} cd examples/go-expvar-example && make build
 
 openshift-deploy: openshift-undeploy
 	@echo Deploying Components to OpenShift

--- a/README.adoc
+++ b/README.adoc
@@ -133,9 +133,9 @@ To deploy the agent, you will need to follow the following commands:
 
 [source,shell]
 ----
-oc create -f deploy/openshift/hawkular-openshift-agent-configmap.yaml -n openshift-infra
-oc process -f deploy/openshift/hawkular-openshift-agent.yaml | oc create -n openshift-infra -f -
-oc adm policy add-cluster-role-to-user hawkular-openshift-agent system:serviceaccount:openshift-infra:hawkular-openshift-agent
+oc create -f deploy/openshift/hawkular-openshift-agent-configmap.yaml -n default
+oc process -f deploy/openshift/hawkular-openshift-agent.yaml | oc create -n default -f -
+oc adm policy add-cluster-role-to-user hawkular-openshift-agent system:serviceaccount:default:hawkular-openshift-agent
 ----
 
 ==== Undeploying the Agent
@@ -144,7 +144,7 @@ If you want to remove the agent from your OpenShift environment, you can do so b
 
 [source,shell]
 ----
-oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles --selector=metrics-infra=agent -n openshift-infra
+oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles --selector=metrics-infra=agent -n default
 oc delete clusterroles hawkular-openshift-agent # this is only needed until this bug is fixed: https://github.com/openshift/origin/issues/12450
 ----
 
@@ -316,7 +316,7 @@ A full Prometheus endpoint configuration can look like this:
   credentials:
     token: your-bearer-token-here
     #username: your-user
-    #password: your-pass
+    #password: secret:my-openshift-secret-name/your-pass
   collection_interval: 1m
   metrics:
   - name: go_memstats_last_gc_time_seconds
@@ -329,14 +329,14 @@ Some things to note about configuring your Prometheus endpoints:
 * Prometheus endpoints can serve metric data in either text or binary form. The agent automatically supports both - there is no special configuration needed. The agent will detect what form the data is in when the endpoint returns it and parses the data accordingly.
 * If this is an endpoint running in an OpenShift pod (and thus this endpoint configuration is found in a config map), you do not specify a full URL; instead you specify the protocol, port, and path and the pod's IP will be used for the hostname. URLs are only specified for those endpoints running outside of OpenShift.
 * The agent supports either http or https endpoints. If the Prometheus endpoint is over the https protocol, you must configure
-the agent with a certificate and private key. This is done by either starting the agent with the two environment variables `HAWKULAR_OPENSHIFT_AGENT_CERT_FILE` and `HAWKULAR_OPENSHIFT_AGENT_PRIVATE_KEY_FILE` or via the Indentity section of the agent's configuration file:
+the agent with a certificate and private key. This is done by either starting the agent with the two environment variables `HAWKULAR_OPENSHIFT_AGENT_CERT_FILE` and `HAWKULAR_OPENSHIFT_AGENT_PRIVATE_KEY_FILE` or via the Identity section of the agent's configuration file:
 [source,yaml]
 ----
 identity:
   cert_file: /path/to/file.crt
   private_key_file: /path/to/file.key
 ----
-* The credentials are optional. If the Prometheus endpoint does require authorization, you can specify the credentials as either a bearer token or a basic username/password.
+* The credentials are optional. If the Prometheus endpoint does require authorization, you can specify the credentials as either a bearer token or a basic username/password. To avoid putting this information in plaintext you can specify an OpenShift secret name that the agent will use to obtain the credentials (e.g. a password value can be "secret:my-secret/password" which tells the agent to look up the password in the "password" entry found within the OpenShift secret named "my-secret").
 * A metric "id" is used when storing the metric to Hawkular Metrics. If you do not specify an "id" for a metric, its "name" will be used as the default. This metric ID will be prefixed with the "metric_id_prefix" if one is defined in the `collector` section of the agent's global configuration file.
 
 Prometheus supports the ability to https://prometheus.io/docs/practices/naming/#labels[label] metrics such as the below:
@@ -392,7 +392,7 @@ A full Jolokia endpoint configuration can look like this:
   credentials:
     token: your-bearer-token-here
     #username: your-user
-    #password: your-pass
+    #password: secret:my-openshift-secret-name/your-pass
   collection_interval: 60s
   metrics:
   - name: java.lang:type=Threading#ThreadCount
@@ -407,18 +407,115 @@ Some things to note about configuring your Jolokia endpoints:
 
 * If this is an endpoint running in an OpenShift pod (and thus this endpoint configuration is found in a config map), you do not specify a full URL; instead you specify the protocol, port, and path and the pod's IP will be used for the hostname. URLs are only specified for those endpoints running outside of OpenShift.
 * The agent supports either http or https endpoints. If the Jolokia endpoint is over the https protocol, you must configure
-the agent with a certificate and private key. This is done by either starting the agent with the two environment variables `HAWKULAR_OPENSHIFT_AGENT_CERT_FILE` and `HAWKULAR_OPENSHIFT_AGENT_PRIVATE_KEY_FILE` or via the Indentity section of the agent's configuration file:
+the agent with a certificate and private key. This is done by either starting the agent with the two environment variables `HAWKULAR_OPENSHIFT_AGENT_CERT_FILE` and `HAWKULAR_OPENSHIFT_AGENT_PRIVATE_KEY_FILE` or via the Identity section of the agent's configuration file:
 [source,yaml]
 ----
 identity:
   cert_file: /path/to/file.crt
   private_key_file: /path/to/file.key
 ----
-* The credentials are optional. If the Jolokia endpoint does require authorization, you can specify the credentials as either a bearer token or a basic username/password.
+* The credentials are optional. If the Jolokia endpoint does require authorization, you can specify the credentials as either a bearer token or a basic username/password. To avoid putting this information in plaintext you can specify an OpenShift secret name that the agent will use to obtain the credentials (e.g. a password value can be "secret:my-secret/password" which tells the agent to look up the password in the "password" entry found within the OpenShift secret named "my-secret").
 * A metric "id" is used when storing the metric to Hawkular Metrics. If you do not specify an "id" for a metric, its "name" will be used as the default.
 * You must specify a metric's "type" as either "counter" or "gauge".
 * A metric "id" is used when storing the metric to Hawkular Metrics. If you do not specify an "id" for a metric, its "name" will be used as the default. This metric ID will be prefixed with the "metric_id_prefix" if one is defined in the `collector` section of the agent's global configuration file.
 * A metric "name" follows a strict format. First is the full MBean name (e.g. `java.lang:type=Threading`) followed by a hash (#) followed by the attribute that contains the metric data (e.g. `ThreadCount`). If the attribute is a composite attribute, then you must append a second hash followed by the composite attribute's subpath name which contains the actual metric value. For example, `java.lang:type=Memory#HeapMemoryUsage#used` will collect the `used` value of the composite attribute `HeapMemoryUsage` from the MBean `java.lang:type=Memory`.
+
+== Generic JSON Endpoints
+
+Hawkular OpenShift Agent has the ability to read any endpoint that exposes metrics in JSON format. So long as the endpoint serves a valid JSON document, the agent can scrape the metrics from that JSON data. One common use-case for this is GoLang's `expvar` feature. A GoLang program can expose its metric data over HTTP in JSON format via expvar (see the link:https://golang.org/pkg/expvar/[GoLang expvar documentation] for more details) - the agent can read this GoLang expvar endpoint to obtain that metric data. A full JSON endpoint configuration can look like this:
+
+[source,yaml]
+----
+- type: json
+  # If this is an endpoint within an OpenShift pod:
+  protocol: https
+  port: 8080
+  path: /debug/vars
+  # If this is an endpoint running outside of OpenShift:
+  #url: "https://yourcorp.com:8080/debug/vars"
+  credentials:
+    token: your-bearer-token-here
+    #username: your-user
+    #password: secret:my-openshift-secret-name/password
+  collection_interval: 60s
+  metrics:
+  - name: loop-counter
+    type: counter
+    description: The number of times the loop was executed.
+----
+
+Some things to note about configuring your JSON endpoints:
+
+* If this is an endpoint running in an OpenShift pod (and thus this endpoint configuration is found in a config map), you do not specify a full URL; instead you specify the protocol, port, and path and the pod's IP will be used for the hostname. URLs are only specified for those endpoints running outside of OpenShift.
+* The agent supports either http or https endpoints. If the JSON endpoint is over the https protocol, you must configure
+the agent with a certificate and private key. This is done by either starting the agent with the two environment variables `HAWKULAR_OPENSHIFT_AGENT_CERT_FILE` and `HAWKULAR_OPENSHIFT_AGENT_PRIVATE_KEY_FILE` or via the Identity section of the agent's configuration file:
+[source,yaml]
+----
+identity:
+  cert_file: /path/to/file.crt
+  private_key_file: /path/to/file.key
+----
+* The credentials are optional. If the JSON endpoint does require authorization, you can specify the credentials as either a bearer token or a basic username/password. To avoid putting this information in plaintext you can specify an OpenShift secret name that the agent will use to obtain the credentials (e.g. a password value can be "secret:my-secret/password" which tells the agent to look up the password in the "password" entry found within the OpenShift secret named "my-secret").
+* If no metrics are specified, all valid metrics in the JSON data will be collected.
+* A metric "id" is used when storing the metric to Hawkular Metrics. If you do not specify an "id" for a metric, its "name" will be used as the default with labels appended to it (see more below).
+* You must specify a metric's "type" as either "counter" or "gauge".
+* A metric "id" is used when storing the metric to Hawkular Metrics. If you do not specify an "id" for a metric, its "name" will be used as the default. This metric ID will be prefixed with the "metric_id_prefix" if one is defined in the `collector` section of the agent's global configuration file.
+* A metric "name" is the name of the top-level JSON element.
+
+The JSON data can include sub-elements under the named top-level elements. In this case, the sub-element names will be used as tags and appended to the metric name enclosed in curly braces. The agent can support maps nested at any level. An example is the best way to illustrate this. Suppose the JSON metric data representing a web application's average response times looks like this:
+
+[source,json]
+----
+{
+   "response.times":
+   {
+      "GET":
+      {
+         "/index.html":9.7,
+         "/store/browse.jsp?product=123":1.3
+      },
+      "POST":
+      {
+         "/admin/query-db":2.1,
+         "/store/buy.jsp#cart":4.0
+      }
+   }
+}
+----
+
+The metric names are always found at the top-level of the JSON data. So in this example, the metric being collected has the base metric name "response.times". 
+
+But notice this data has a map sub-element under the top element indicating this "metric" is really a collection of related metrics (for those familiar with Prometheus, we can call this the "metric family name"). This map has two entries with key names "GET" and "POST". Under each of these are more maps, each keyed with a web application request path (e.g. "/index.html" or "/admin/query-db") whose values are the actual numeric metric data - the average response time for each requested endpoint.
+
+The Hawkular OpenShift Agent will be able to collect and store this family of metrics named "response.times". It reads the child map entries and considers each map key a label value which will be appended to the metric name to build the metric ID and will be used as a tag on the metric when storing in Hawkular Metrics. The agent recursively decends the JSON tree building new labels until it reaches the numeric metric data.
+
+For this example, the agent will end up storing in Hawkular Metrics the following four individual metrics:
+
+[cols="1,1,2a"]
+|===
+|Metric ID|Metric Value|Tags
+
+|response.times{label1=GET,label2=/index.html"}
+|9.7
+|* label1=GET1
+ * label2=/index.html
+
+|response.times{label1=GET,label2=/store/browse.jsp?product=123"}
+|1.3
+|* label1=GET
+ * label2=/store/browse.jsp?product=123
+
+|response.times{label1=POST,label2=/admin/query-db"}
+|2.1
+|* label1=POST
+ * label2=/admin/query-db
+
+|response.times{label1=POST,label2=/store/buy.jsp#cart"}
+|4.0
+|* label1=POST
+ * label2=/store/buy.jsp#cart
+
+|===
 
 == Environment Variables
 
@@ -463,7 +560,7 @@ hawkular_server:
   credentials:
     username: VALUE
 ----
-|Username used when connecting to Hawkular Metrics
+|Username used when connecting to Hawkular Metrics. Can use OpenShift secrets via the "secret:" prefix.
 
 |HAWKULAR_SERVER_PASSWORD
 |
@@ -473,7 +570,7 @@ hawkular_server:
   credentials:
     password: VALUE
 ----
-|Password used when connecting to Hawkular Metrics
+|Password used when connecting to Hawkular Metrics. Can use OpenShift secrets via the "secret:" prefix.
 
 |HAWKULAR_SERVER_TOKEN
 |
@@ -483,7 +580,7 @@ hawkular_server:
   credentials:
     token: VALUE
 ----
-|Bearer token used when connecting to Hawkular Metrics. If specified, username and password are ignored.
+|Bearer token used when connecting to Hawkular Metrics. If specified, username and password are ignored. Can use OpenShift secrets via the "secret:" prefix.
 
 |HAWKULAR_OPENSHIFT_AGENT_CERT_FILE
 |

--- a/collector/impl/json_metrics_collector.go
+++ b/collector/impl/json_metrics_collector.go
@@ -1,0 +1,385 @@
+/*
+   Copyright 2017 Red Hat, Inc. and/or its affiliates
+   and other contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package impl
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"strconv"
+	"time"
+
+	hmetrics "github.com/hawkular/hawkular-client-go/metrics"
+
+	"github.com/hawkular/hawkular-openshift-agent/collector"
+	"github.com/hawkular/hawkular-openshift-agent/config/security"
+	"github.com/hawkular/hawkular-openshift-agent/config/tags"
+	"github.com/hawkular/hawkular-openshift-agent/http"
+	"github.com/hawkular/hawkular-openshift-agent/json"
+	"github.com/hawkular/hawkular-openshift-agent/log"
+	"github.com/hawkular/hawkular-openshift-agent/util/math"
+)
+
+type JSONMetricsCollector struct {
+	ID            collector.CollectorID
+	Identity      *security.Identity
+	Endpoint      *collector.Endpoint
+	Environment   map[string]string
+	metricNameMap map[string]collector.MonitoredMetric
+}
+
+func NewJSONMetricsCollector(id collector.CollectorID, identity security.Identity, endpoint collector.Endpoint, env map[string]string) (mc *JSONMetricsCollector) {
+	mc = &JSONMetricsCollector{
+		ID:          id,
+		Identity:    &identity,
+		Endpoint:    &endpoint,
+		Environment: env,
+	}
+
+	// Put all metrics in a map so we can quickly look them up to know which metrics should be stored and which are to be ignored.
+	mc.metricNameMap = make(map[string]collector.MonitoredMetric, len(endpoint.Metrics))
+	for _, m := range endpoint.Metrics {
+		mc.metricNameMap[m.Name] = m
+	}
+
+	return
+}
+
+// GetId implements a method from MetricsCollector interface
+func (mc *JSONMetricsCollector) GetID() collector.CollectorID {
+	return mc.ID
+}
+
+// GetEndpoint implements a method from MetricsCollector interface
+func (mc *JSONMetricsCollector) GetEndpoint() *collector.Endpoint {
+	return mc.Endpoint
+}
+
+// GetAdditionalEnvironment implements a method from MetricsCollector interface
+func (mc *JSONMetricsCollector) GetAdditionalEnvironment() map[string]string {
+	return mc.Environment
+}
+
+// CollectMetrics does the real work of actually connecting to a remote JSON endpoint (like Golang Expvar)
+// and collects all metrics it find there, and returns those metrics.
+// CollectMetrics implements a method from MetricsCollector interface
+func (mc *JSONMetricsCollector) CollectMetrics() (metrics []hmetrics.MetricHeader, err error) {
+
+	url := mc.Endpoint.URL
+
+	httpConfig := http.HttpClientConfig{
+		Identity: mc.Identity,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: mc.Endpoint.TLS.Skip_Certificate_Validation,
+		},
+	}
+	httpClient, err := httpConfig.BuildHttpClient()
+	if err != nil {
+		err = fmt.Errorf("Failed to create http client for JSON endpoint [%v]. err=%v", url, err)
+		return
+	}
+
+	// Get the JSON endpoint data
+	jsonData, err := json.Scrape(url, &mc.Endpoint.Credentials, httpClient)
+	if err != nil {
+		return
+	}
+
+	// Listen to a channel that will receive all the metrics so we can store them in our metrics array
+	metrics = make([]hmetrics.MetricHeader, 0)
+	metricsChan := make(chan hmetrics.MetricHeader)
+	go func() {
+		for m := range metricsChan {
+			metrics = append(metrics, m)
+		}
+	}()
+
+	// Walk the JSON data and send all the valid metrics found there to the channel
+	context := processingContext{
+		metricsChan: metricsChan,
+		now:         time.Now(),
+	}
+
+	for k, v := range jsonData {
+		context.currentMetricId = ""
+		context.currentMetricTags = []tags.Tags{}
+		mc.processJSON(context, k, v)
+	}
+
+	close(metricsChan)
+
+	if log.IsTrace() {
+		var buffer bytes.Buffer
+		n := 0
+		buffer.WriteString(fmt.Sprintf("JSON metrics collected from endpoint [%v]:\n", url))
+		for _, m := range metrics {
+			buffer.WriteString(fmt.Sprintf("%v\n", m))
+			n += len(m.Data)
+		}
+		buffer.WriteString(fmt.Sprintf("==TOTAL EXPVAR METRICS COLLECTED=%v\n", n))
+		log.Trace(buffer.String())
+	}
+
+	return
+}
+
+// CollectMetricDetails implements a method from MetricsCollector interface
+func (mc *JSONMetricsCollector) CollectMetricDetails(metricNames []string) ([]collector.MetricDetails, error) {
+	// json does not provide this information
+	return make([]collector.MetricDetails, 0), nil
+}
+
+func (mc *JSONMetricsCollector) processJSON(context processingContext, jsonName string, jsonValue interface{}) {
+	defer context.reset(context.currentMetricId)
+
+	url := mc.Endpoint.URL
+	metricId := context.buildMetricId(jsonName)
+	if context.currentMetricId != "" {
+		context.currentMetricTags = append(context.currentMetricTags, tags.Tags{fmt.Sprintf("label%v", len(context.currentMetricTags)+1): jsonName})
+	}
+
+	metricType := hmetrics.Gauge
+	if len(mc.metricNameMap) > 0 {
+		if monitoredMetric, ok := mc.metricNameMap[metricId]; ok {
+			metricType = monitoredMetric.Type
+		} else {
+			log.Tracef("Told not to collect JSON metric [%v] from endpoint [%v]", metricId, url)
+			return
+		}
+	}
+
+	switch vv := jsonValue.(type) {
+
+	case float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		// terminal json element - metric has a numeric value
+		val, err := strconv.ParseFloat(fmt.Sprint(jsonValue), 64)
+		if err == nil {
+			currentMetric := hmetrics.MetricHeader{
+				ID:     metricId,
+				Tenant: mc.Endpoint.Tenant,
+				Type:   metricType,
+				Data: []hmetrics.Datapoint{
+					hmetrics.Datapoint{
+						Timestamp: context.now,
+						Value:     val,
+						Tags:      context.tagsClone(),
+					},
+				},
+			}
+
+			context.metricsChan <- currentMetric
+		} else {
+			log.Warningf("Failed to convert value to float [%v=%v] from URL=[%v]. err=%v", metricId, jsonValue, url, err)
+		}
+
+	case string:
+		// terminal json element - metric has a string value
+		log.Debugf("JSON string metrics not supported yet. [%v%v] from url [%v]", metricId, context.tagsString(), url)
+
+	case bool:
+		// terminal json element - metric is a boolean that we will convert to a number. false=0.0, true=1.0
+		var val float64
+		if jsonValue.(bool) {
+			val = 1.0
+		} else {
+			val = 0.0
+		}
+		currentMetric := hmetrics.MetricHeader{
+			ID:     metricId,
+			Tenant: mc.Endpoint.Tenant,
+			Type:   metricType,
+			Data: []hmetrics.Datapoint{
+				hmetrics.Datapoint{
+					Timestamp: context.now,
+					Value:     val,
+					Tags:      context.tagsClone(),
+				},
+			},
+		}
+		context.metricsChan <- currentMetric
+
+	case []interface{}:
+		if len(vv) == 0 {
+			break // nothing to do, array is empty
+		}
+
+		switch vvv := vv[0].(type) {
+		case float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			{
+				// terminal json element - this is a flat array of numeric values
+				// We don't know anything about the data, but we'll assume calculating
+				// some statistics (min, max, avg, stddev) would be useful.
+				tagName := "array_stat"
+
+				minMetric := hmetrics.MetricHeader{
+					ID:     metricId,
+					Tenant: mc.Endpoint.Tenant,
+					Type:   hmetrics.Gauge,
+					Data: []hmetrics.Datapoint{
+						hmetrics.Datapoint{
+							Timestamp: context.now,
+							Tags:      context.tagsClone(),
+						},
+					},
+				}
+				minMetric.Data[0].Tags[tagName] = "min"
+
+				maxMetric := hmetrics.MetricHeader{
+					ID:     metricId,
+					Tenant: mc.Endpoint.Tenant,
+					Type:   hmetrics.Gauge,
+					Data: []hmetrics.Datapoint{
+						hmetrics.Datapoint{
+							Timestamp: context.now,
+							Tags:      context.tagsClone(),
+						},
+					},
+				}
+				maxMetric.Data[0].Tags[tagName] = "max"
+
+				avgMetric := hmetrics.MetricHeader{
+					ID:     metricId,
+					Tenant: mc.Endpoint.Tenant,
+					Type:   hmetrics.Gauge,
+					Data: []hmetrics.Datapoint{
+						hmetrics.Datapoint{
+							Timestamp: context.now,
+							Tags:      context.tagsClone(),
+						},
+					},
+				}
+				avgMetric.Data[0].Tags[tagName] = "avg"
+
+				stddevMetric := hmetrics.MetricHeader{
+					ID:     metricId,
+					Tenant: mc.Endpoint.Tenant,
+					Type:   hmetrics.Gauge,
+					Data: []hmetrics.Datapoint{
+						hmetrics.Datapoint{
+							Timestamp: context.now,
+							Tags:      context.tagsClone(),
+						},
+					},
+				}
+				stddevMetric.Data[0].Tags[tagName] = "stddev"
+
+				isValid := true
+				floatArr := make([]float64, len(vv))
+				for i, metricArrItem := range vv {
+					val, err := strconv.ParseFloat(fmt.Sprint(metricArrItem), 64)
+					if err == nil {
+						floatArr[i] = val
+					} else {
+						log.Warningf("Failed to convert value to float [%v=%v] from URL=[%v]. err=%v", metricId, metricArrItem, url, err)
+						isValid = false
+						break
+					}
+				}
+
+				if isValid {
+					avgValue := math.Avg(floatArr)
+					minMetric.Data[0].Value = math.Min(floatArr)
+					maxMetric.Data[0].Value = math.Max(floatArr)
+					avgMetric.Data[0].Value = avgValue
+					stddevMetric.Data[0].Value = math.Stddev(floatArr, avgValue)
+					context.metricsChan <- minMetric
+					context.metricsChan <- maxMetric
+					context.metricsChan <- avgMetric
+					context.metricsChan <- stddevMetric
+				}
+			}
+		case map[string]interface{}:
+			{
+				// recursively process the values of the array which are maps
+				for _, metricArrItem := range vv {
+					// each map entry is a separate metric
+					for metricKey, metricValue := range metricArrItem.(map[string]interface{}) {
+						context.currentMetricId = metricId
+						mc.processJSON(context, metricKey, metricValue)
+					}
+				}
+			}
+		default:
+			{
+				log.Debugf("JSON collector cannot process the type [%T] in array for key [%v%v]. url=[%v]", vvv, metricId, context.tagsString(), url)
+			}
+		}
+
+	case map[string]interface{}:
+		// recursively process the values of the map to get the individual metrics
+		for metricKey, metricValue := range vv {
+			context.currentMetricId = metricId
+			mc.processJSON(context, metricKey, metricValue)
+		}
+
+	default:
+		log.Debugf("JSON collector cannot process the type [%T] for key [%v%v]. url=[%v]", vv, metricId, context.tagsString(), url)
+	}
+}
+
+// Context struct and methods
+
+type processingContext struct {
+	now               time.Time
+	metricsChan       chan hmetrics.MetricHeader
+	currentMetricId   string
+	currentMetricTags []tags.Tags
+}
+
+func (c *processingContext) buildMetricId(jsonName string) string {
+	if c.currentMetricId != "" {
+		return c.currentMetricId
+	} else {
+		return jsonName
+	}
+}
+
+func (c *processingContext) reset(metricId string) {
+	c.currentMetricId = metricId
+	if len(c.currentMetricTags) > 0 {
+		c.currentMetricTags = c.currentMetricTags[:len(c.currentMetricTags)-1] // pop the end of the array off
+	}
+}
+
+func (c *processingContext) tagsClone() tags.Tags {
+	newTags := tags.Tags{}
+	for _, t := range c.currentMetricTags {
+		newTags.AppendTags(t)
+	}
+	return newTags
+}
+
+func (c *processingContext) tagsString() string {
+	var buffer bytes.Buffer
+	comma := ""
+
+	buffer.WriteString("")
+	for _, t := range c.currentMetricTags {
+		for k, v := range t {
+			buffer.WriteString(fmt.Sprintf("%v%v=%v", comma, k, v))
+			comma = ","
+		}
+	}
+
+	str := buffer.String()
+	if str != "" {
+		str = fmt.Sprintf("{%v}", str)
+	}
+
+	return str
+}

--- a/collector/manager/metrics_collector_creator.go
+++ b/collector/manager/metrics_collector_creator.go
@@ -35,6 +35,10 @@ func CreateMetricsCollector(id collector.CollectorID, identity security.Identity
 		{
 			theCollector = impl.NewJolokiaMetricsCollector(id, identity, endpoint, env)
 		}
+	case collector.ENDPOINT_TYPE_JSON:
+		{
+			theCollector = impl.NewJSONMetricsCollector(id, identity, endpoint, env)
+		}
 	default:
 		{
 			err = fmt.Errorf("Unknown endpoint type [%v]", endpoint.Type)

--- a/collector/metrics_endpoint.go
+++ b/collector/metrics_endpoint.go
@@ -32,6 +32,7 @@ type EndpointType string
 const (
 	ENDPOINT_TYPE_PROMETHEUS EndpointType = "prometheus"
 	ENDPOINT_TYPE_JOLOKIA                 = "jolokia"
+	ENDPOINT_TYPE_JSON                    = "json"
 )
 
 // MonitoredMetric provides information about a specific metric that is to be collected.
@@ -125,7 +126,7 @@ func (e *Endpoint) ValidateEndpoint() error {
 	if e.Type == "" {
 		return fmt.Errorf("Endpoint [%v] is missing a valid type", e.URL)
 	} else {
-		if e.Type != ENDPOINT_TYPE_JOLOKIA && e.Type != ENDPOINT_TYPE_PROMETHEUS {
+		if e.Type != ENDPOINT_TYPE_JOLOKIA && e.Type != ENDPOINT_TYPE_PROMETHEUS && e.Type != ENDPOINT_TYPE_JSON {
 			return fmt.Errorf("Endpoint [%v] has invalid type [%v]", e.URL, e.Type)
 		}
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -35,3 +35,10 @@ endpoints:
     collection_interval: 10s
     tags:
       endpoint-name: prometheus-python-example
+  # go-expvar-example
+  - type: json
+    enabled: false
+    url: http://127.0.0.1:8181/debug/vars
+    collection_interval: 10s
+    tags:
+      endpoint-name: go-expvar-example

--- a/examples/go-expvar-example/Dockerfile
+++ b/examples/go-expvar-example/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.7.5
+
+EXPOSE 8181
+
+RUN mkdir -p /opt/example
+
+COPY _output/go-expvar-example /opt/example
+
+# Set a default user, any value will work here.
+# Otherwise the default is root and can fail in certain OpenShift installations
+USER 12345
+
+ENTRYPOINT ["/opt/example/go-expvar-example"]

--- a/examples/go-expvar-example/Makefile
+++ b/examples/go-expvar-example/Makefile
@@ -1,0 +1,44 @@
+# Copyright 2017 Red Hat, Inc. and/or its affiliates
+# and other contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_NAME = hawkular/hawkular-openshift-agent-example-go-expvar
+DOCKER_VERSION ?= latest
+DOCKER_TAG = ${DOCKER_NAME}:${DOCKER_VERSION}
+
+HAWKULAR_OPENSHIFT_AGENT_EXAMPLE_GO_EXPVAR_HOSTNAME ?= "hawkular-openshift-agent-example-go-expvar-$(shell oc project -q).$(shell oc version | grep 'Server ' | awk '{print $$2;}' | egrep -o '([0-9]{1,3}[.]){3}[0-9]{1,3}').xip.io"
+
+GOPATH := ${GOPATH}/src/github.com/hawkular/hawkular-openshift-agent/examples/go-expvar-example
+
+all: clean compile build
+
+clean:
+	@echo Cleaning...
+	rm -f go-expvar-example
+	rm -rf ${GOPATH}/_output
+
+compile:
+	@echo Compiling...
+	cd ${GOPATH}/src/go-expvar-example && go build -o ${GOPATH}/_output/go-expvar-example
+
+build: compile
+	docker build -t ${DOCKER_TAG} .
+
+openshift-deploy: openshift-undeploy
+	@echo Deploying the Go Expvar Example to OpenShift. Using project `oc project --short`
+	oc process -f go-expvar.yaml -v IMAGE_VERSION=${DOCKER_VERSION} -v HAWKULAR_OPENSHIFT_AGENT_EXAMPLE_GO_EXPVAR_HOSTNAME=${HAWKULAR_OPENSHIFT_AGENT_EXAMPLE_GO_EXPVAR_HOSTNAME} | oc create -f -
+
+openshift-undeploy:
+	@echo Undeploying the Go Expvar Example from OpenShift. Using project `oc project --short`
+	oc delete all,secrets,sa,templates,configmaps --selector=hawkular-openshift-agent-example=go-expvar

--- a/examples/go-expvar-example/go-expvar.yaml
+++ b/examples/go-expvar-example/go-expvar.yaml
@@ -1,0 +1,83 @@
+id: hawkular-openshift-agent-example-go-expvar
+kind: Template
+apiVersion: v1
+name: hawkular-openshift-agent-example-go-expvar
+metadata:
+  name: hawkular-openshift-agent-example-go-expvar
+  labels:
+    hawkular-openshift-agent-example: go-expvar
+parameters:
+- description: The version of the image to use
+  name: IMAGE_VERSION
+  value: latest
+- description: The hostname where the route can be accessed.
+  name: HAWKULAR_OPENSHIFT_AGENT_EXAMPLE_GO_EXPVAR_HOSTNAME
+  value:
+objects:
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    name: hawkular-openshift-agent-example-go-expvar
+    labels:
+      name: hawkular-openshift-agent-example-go-expvar
+      hawkular-openshift-agent-example: go-expvar
+  spec:
+    selector:
+      name: hawkular-openshift-agent-example-go-expvar
+    replicas: 1
+    template:
+      version: v1
+      metadata:
+        labels:
+          name: hawkular-openshift-agent-example-go-expvar
+          hawkular-openshift-agent-example: go-expvar
+      spec:
+        containers:
+        - image: hawkular/hawkular-openshift-agent-example-go-expvar:${IMAGE_VERSION}
+          name: hawkular-openshift-agent-example-go-expvar
+        volumes:
+        - name: hawkular-openshift-agent
+          configMap:
+            name: hawkular-openshift-agent-example-go-expvar
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: hawkular-openshift-agent-example-go-expvar
+    labels:
+      name: hawkular-openshift-agent-example-go-expvar
+      hawkular-openshift-agent-example: go-expvar
+  spec:
+    ports:
+      - protocol: TCP
+        port: 8181
+    selector:
+      name: hawkular-openshift-agent-example-go-expvar
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: hawkular-openshift-agent
+    labels:
+      name: hawkular-openshift-agent-example-go-expvar
+      hawkular-openshift-agent-example: go-expvar
+  spec:
+    host: ${HAWKULAR_OPENSHIFT_AGENT_EXAMPLE_GO_EXPVAR_HOSTNAME}
+    path: /debug/vars
+    to:
+      kind: Service
+      name: hawkular-openshift-agent-example-go-expvar
+      weight: 100
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: hawkular-openshift-agent-example-go-expvar
+    labels:
+      name: hawkular-openshift-agent-example-go-expvar
+      hawkular-openshift-agent-example: go-expvar
+  data:
+    hawkular-openshift-agent: |
+      endpoints:
+      - type: expvar
+        protocol: "http"
+        port: 8181
+        path: /debug/vars
+        collection_interval: 30s

--- a/examples/go-expvar-example/src/go-expvar-example/go-expvar-example.go
+++ b/examples/go-expvar-example/src/go-expvar-example/go-expvar-example.go
@@ -1,0 +1,192 @@
+/*
+   Copyright 2017 Red Hat, Inc. and/or its affiliates
+   and other contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"expvar" // this has the side effect of registering the /debug/vars HTTP endpoint.
+	"flag"
+	"fmt"
+	"math"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"time"
+)
+
+// Type to be an example of metric data in maps-o-maps.
+// Outer key is HTTP method, inner key is request path, value is response time
+type SimulatedHttpRequests map[string]map[string]float64
+
+func (s SimulatedHttpRequests) String() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// WaveDataType to be an example of metric data in an array
+type WaveDataType struct {
+	data []float64
+}
+
+func (w WaveDataType) String() string {
+	b, _ := json.Marshal(w.data)
+	return string(b)
+}
+
+// Command line arguments
+var (
+	argPort = flag.String("port", "8181", "The port to emit the expvar JSON data.")
+)
+
+// Some internals
+var (
+	animalTypes = []string{"Deer", "Goose", "Squirrel", "Turkey"}
+	waveData    = WaveDataType{
+		data: make([]float64, 100),
+	}
+	simulatedHttp = SimulatedHttpRequests(make(map[string]map[string]float64, 0))
+)
+
+// Exposed Data
+var (
+	animals    = expvar.NewMap("expvar.example.animals-map")
+	loopCount  = expvar.NewFloat("expvar.example.loop-counter")
+	randomNum  = expvar.NewInt("expvar.example.random-number")
+	theHourStr = expvar.NewString("expvar.example.current-hour")
+)
+
+func init() {
+	for _, a := range animalTypes {
+		animals.AddFloat(a, 0.0)
+	}
+
+	loopCount.Set(0.0)
+	randomNum.Set(0)
+	theHourStr.Set("")
+
+	expvar.Publish("expvar.example.wave", waveData)
+	expvar.Publish("expvar.example.http.response.times", simulatedHttp)
+}
+
+func main() {
+	// process command line
+	flag.Parse()
+
+	if _, err := strconv.Atoi(*argPort); err != nil {
+		panic("Invalid port: " + *argPort)
+	}
+
+	// start up the listener
+	fmt.Println("Go Expvar Example. Will listen on port", *argPort, "...")
+	sock, err := net.Listen("tcp", ":"+*argPort)
+	if err != nil {
+		panic("Cannot start listener. err=" + err.Error())
+	}
+
+	go func() {
+		if err := http.Serve(sock, nil); err != nil {
+			fmt.Println("HTTP Server stopped.", err.Error())
+		}
+	}()
+
+	// periodically generate some random metric data every few seconds
+	ticker := time.NewTicker(time.Second * 10)
+	go func() {
+		for _ = range ticker.C {
+			// loop counter
+			loopCount.Add(1.0)
+
+			// pick an animal and add to its count
+			pickAnimal := rand.Intn(len(animalTypes))
+			animals.AddFloat(animalTypes[pickAnimal], 1.0)
+
+			// generate a random number
+			randomNum.Set(rand.Int63n(100))
+
+			// report what the current hour is local time
+			now := time.Now().Local()
+			theHourStr.Set(fmt.Sprintf("%4d-%0d-%0d-%0d", now.Year(), now.Month(), now.Day(), now.Hour()))
+
+			// fill in the sin wave from right to left
+			amplitude := 10.0
+			frequency := 0.025
+			t, _ := strconv.ParseFloat(loopCount.String(), 64)
+			copy(waveData.data, waveData.data[1:])
+			waveData.data[len(waveData.data)-1] = math.Sin(frequency*t) * amplitude
+
+			// create a simulated request and its response time
+			simulateHttpRequest()
+		}
+	}()
+
+	// wait forever, or at least until we are told to exit
+	waitForTermination()
+}
+
+func waitForTermination() {
+	// Channel that is notified when we are done and should exit
+	var doneChan = make(chan bool)
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt)
+	go func() {
+		for _ = range signalChan {
+			fmt.Println("Termination Signal Received")
+			doneChan <- true
+		}
+	}()
+
+	<-doneChan
+}
+
+func simulateHttpRequest() {
+	methods := []string{"GET", "POST"}
+	paths := []string{
+		"/index.html",
+		"/store/browse.jsp?product=123",
+		"/store/buy.jsp#cart",
+		"/admin/query-db",
+	}
+
+	// simulate an http request
+	method := methods[rand.Intn(len(methods))]
+	path := paths[rand.Intn(len(paths))]
+	responseTime := rand.Float64() * 10.0 // simulate respond times between 0 and 10 seconds
+
+	// Publish this example metric in two ways:
+	// 1. Within a map-in-a-map
+	// 2. As a flat metric
+
+	// Map-in-a-map
+	methodMap, ok := simulatedHttp[method]
+	if !ok {
+		methodMap = make(map[string]float64, 0)
+		simulatedHttp[method] = methodMap
+	}
+	methodMap[path] = responseTime
+
+	// Flat
+	flatMetricName := fmt.Sprintf("expvar.example.http.response.time.%v-%v", method, path)
+	flatMetricVar := expvar.Get(flatMetricName)
+	if flatMetricVar == nil {
+		flatMetricVar = expvar.NewFloat(flatMetricName)
+	}
+	flatMetricVar.(*expvar.Float).Set(responseTime)
+}

--- a/json/json_scraper.go
+++ b/json/json_scraper.go
@@ -1,0 +1,75 @@
+/*
+   Copyright 2017 Red Hat, Inc. and/or its affiliates
+   and other contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hawkular/hawkular-openshift-agent/config/security"
+	"github.com/hawkular/hawkular-openshift-agent/log"
+)
+
+const userAgent string = "Hawkular/Hawkular-OpenShift-Agent"
+
+func Scrape(url string, credentials *security.Credentials, client *http.Client) (map[string]interface{}, error) {
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot create HTTP GET request for JSON URL [%v]: err= %v", url, err)
+	}
+
+	req.Header.Add("User-Agent", userAgent)
+
+	// Add the auth header if we need one
+	headerName, headerValue, err := credentials.GetHttpAuthHeader()
+	if err != nil {
+		return nil, fmt.Errorf("Cannot create HTTP GET request auth header for JSON URL [%v]: err= %v", url, err)
+	}
+	if headerName != "" {
+		req.Header.Add(headerName, headerValue)
+	}
+
+	// Submit the request to read the URL
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot scrape JSON URL [%v]: err=%v", url, err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("JSON URL [%v] returned error status [%v/%v]", url, resp.StatusCode, resp.Status)
+	}
+
+	log.Tracef("JSON URL [%v] returned data [%v/%v]", url, resp.StatusCode, resp.Status)
+
+	// Perform ad-hoc JSON unmarshalling
+	decoder := json.NewDecoder(resp.Body)
+	var unmarshalledData interface{}
+	if err = decoder.Decode(&unmarshalledData); err != nil {
+		return nil, fmt.Errorf("Cannot unmarshal JSON data from URL [%v]: err=%v", url, err)
+	}
+
+	if d, ok := unmarshalledData.(map[string]interface{}); ok {
+		return d, nil
+	} else {
+		return nil, fmt.Errorf("Cannot unmarshal JSON data from URL [%v]", url)
+	}
+}

--- a/storage/metrics_storage.go
+++ b/storage/metrics_storage.go
@@ -161,6 +161,7 @@ func (ms *MetricsStorageManager) consumeMetrics() {
 
 		if err != nil {
 			log.Warningf("Failed to store metrics. err=%v", err)
+			log.Tracef("These metrics failed to be stored: %v", metrics)
 		} else {
 			log.Debugf("Stored datapoints for [%v] metrics", len(metrics))
 			if log.IsTrace() {

--- a/util/math/math.go
+++ b/util/math/math.go
@@ -1,0 +1,77 @@
+/*
+   Copyright 2017 Red Hat, Inc. and/or its affiliates
+   and other contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package math
+
+import (
+	"math"
+)
+
+func Min(numbers []float64) float64 {
+	if len(numbers) == 0 {
+		return 0.0
+	}
+	m := math.NaN()
+	for _, n := range numbers {
+		if math.IsNaN(m) || n < m {
+			m = n
+		}
+	}
+	return m
+}
+
+func Max(numbers []float64) float64 {
+	if len(numbers) == 0 {
+		return 0.0
+	}
+	m := math.NaN()
+	for _, n := range numbers {
+		if math.IsNaN(m) || n > m {
+			m = n
+		}
+	}
+	return m
+}
+
+func Sum(numbers []float64) float64 {
+	total := 0.0
+	for _, n := range numbers {
+		total += n
+	}
+	return total
+}
+
+func Avg(numbers []float64) float64 {
+	if len(numbers) == 0 {
+		return 0.0
+	}
+	return Sum(numbers) / float64(len(numbers))
+}
+
+// Yes, this func could calc the mean itself, but if the caller already did that, no sense in doing it again.
+// Let the caller pass in Avg(numbers) if mean is not yet calculated.
+func Stddev(numbers []float64, mean float64) float64 {
+	if len(numbers) == 0 {
+		return 0.0
+	}
+	total := 0.0
+	for _, n := range numbers {
+		total += math.Pow(n-mean, 2)
+	}
+	v := total / float64(len(numbers))
+	return math.Sqrt(v)
+}

--- a/util/math/math_test.go
+++ b/util/math/math_test.go
@@ -1,0 +1,87 @@
+/*
+   Copyright 2017 Red Hat, Inc. and/or its affiliates
+   and other contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package math
+
+import (
+	"math"
+	"testing"
+)
+
+func TestAvg(t *testing.T) {
+	assertEquals(t, 2.5, Avg([]float64{1.0, 2.5, 4.0}), "Avg is broken")
+	assertEquals(t, 0.0, Avg([]float64{}), "Avg is broken")
+}
+
+func TestStddev(t *testing.T) {
+	arr := []float64{1.0, 1.0, 1.0}
+	assertEquals(t, 0.0, Stddev(arr, Avg(arr)), "Stddev is broken")
+	arr = []float64{6.0, 2.0, 3.0, 1.0}
+	assertEquals(t, 1.87, Stddev(arr, Avg(arr)), "Stddev is broken")
+	assertEquals(t, 0.0, Stddev([]float64{}, 0.0), "Stddev is broken")
+}
+
+func TestSum(t *testing.T) {
+	assertEquals(t, 10.5, Sum([]float64{1.0, 2.5, 3.5, 3.5}), "Sum is broken")
+	assertEquals(t, 0.0, Sum([]float64{}), "Sum is broken")
+}
+
+func TestMin(t *testing.T) {
+	assertEquals(t, -1.25, Min([]float64{2.0, -1.25, 4.5, 5.5}), "Min is broken")
+	assertEquals(t, 2.5, Min([]float64{2.5, 4.5, 5.5}), "Min is broken")
+	assertEquals(t, 1.5, Min([]float64{1.5, math.NaN(), 5.5}), "Min is broken")
+	assertEquals(t, 0.0, Min([]float64{}), "Min is broken")
+	if !math.IsNaN(Min([]float64{math.NaN(), math.NaN()})) {
+		t.Errorf("Min is broken")
+	}
+	if !math.IsInf(Min([]float64{math.Inf(1)}), 1) {
+		t.Errorf("Min is broken")
+	}
+	if !math.IsInf(Min([]float64{math.Inf(-1)}), -1) {
+		t.Errorf("Min is broken")
+	}
+	if !math.IsInf(Min([]float64{math.Inf(-1), 1.0}), -1) {
+		t.Errorf("Min is broken")
+	}
+	assertEquals(t, 1.5, Min([]float64{math.Inf(1), 1.5}), "Min is broken")
+}
+
+func TestMax(t *testing.T) {
+	assertEquals(t, -1.25, Max([]float64{-2.0, -1.25, -4.5, -5.5}), "Max is broken")
+	assertEquals(t, 5.5, Max([]float64{2.0, 4.5, 5.5}), "Max is broken")
+	assertEquals(t, 5.5, Max([]float64{1.0, math.NaN(), 5.5}), "Max is broken")
+	assertEquals(t, 0.0, Max([]float64{}), "Max is broken")
+	if !math.IsNaN(Max([]float64{math.NaN(), math.NaN()})) {
+		t.Errorf("Max is broken")
+	}
+	if !math.IsInf(Max([]float64{math.Inf(1)}), 1) {
+		t.Errorf("Max is broken")
+	}
+	if !math.IsInf(Max([]float64{math.Inf(-1)}), -1) {
+		t.Errorf("Max is broken")
+	}
+	if !math.IsInf(Max([]float64{math.Inf(1), 1.0}), 1) {
+		t.Errorf("Max is broken")
+	}
+	assertEquals(t, 1.5, Max([]float64{math.Inf(-1), 1.5}), "Max is broken")
+}
+
+func assertEquals(t *testing.T, expected float64, actual float64, msg string) {
+	if diff := math.Abs(expected - actual); diff > 0.001 {
+		t.Errorf("%v: expected=[%v], actual=[%v], diff=[%v]", msg, expected, actual, diff)
+	}
+}


### PR DESCRIPTION
Go has the ability to export variables (in a very similar way that Prometheus client exposes Prometheus data). This PR introduces a new endpoint type supported by the agent "json" that reads expvar endpoints (which is JSON data). This is generically applicable for ANY endpoint that wants to expose ANY data so long as it is in JSON format. So if you have any http endpoint that exposes metric data in JSON format you can use this (doesn't have to be expvar or even implemented in Go).